### PR TITLE
Support wait ANY_COMPLETED

### DIFF
--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -633,7 +633,14 @@ def wait(fs, return_when=ALL_COMPLETED, THREADPOOL_SIZE=64,
                 time.sleep(WAIT_DUR_SEC)
 
     elif return_when == ANY_COMPLETED:
-        raise NotImplementedError()
+        while True:
+            fs_dones, fs_notdones = _wait(fs, THREADPOOL_SIZE)
+
+            if len(fs_dones) != 0:
+                return fs_dones, fs_notdones
+            else:
+                time.sleep(WAIT_DUR_SEC)
+
     elif return_when == ALWAYS:
         return _wait(fs, THREADPOOL_SIZE)
     else:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -223,5 +223,44 @@ class ConfigErrors(unittest.TestCase):
                 with pytest.raises(Exception) as excinfo:
                     pywren.lambda_executor(config)
                 assert 'python version' in str(excinfo.value)
-                        
 
+# skipping those tests in CI because of stability concerns
+@pytest.mark.skip                    
+class WaitTest(unittest.TestCase):
+    # FIXME: for stability, we should proabbly use the local dummy executor,
+    # but currently the dummy invoker impl does not support wait()
+    def setUp(self):
+        self.wrenexec = pywren.default_executor()
+
+    def test_all_complete(self):
+        def wait_10x_sec_and_plus_one(x):
+            time.sleep(10*x)
+            return x + 1
+
+        N = 3
+        x = np.arange(N)
+
+        futures = pywren.default_executor().map(wait_10x_sec_and_plus_one, x)
+
+        fs_dones, fs_notdones = pywren.wait(futures,
+                                        return_when=pywren.wren.ALL_COMPLETED)
+        res =np.array([f.result() for f in fs_dones])
+        np.testing.assert_array_equal(res, x+1)
+
+    def test_any_complete(self):
+        def wait_10x_sec_and_plus_one(x):
+            time.sleep(10*x)
+            return x + 1
+
+        N = 3
+        x = np.arange(N)
+
+        futures = pywren.default_executor().map(wait_10x_sec_and_plus_one, x)
+
+        fs_notdones = futures
+        for xi in x:
+            fs_dones, fs_notdones = pywren.wait(fs_notdones,
+                                            return_when=pywren.wren.ANY_COMPLETED,
+                                            WAIT_DUR_SEC=1)
+            res =np.array([f.result() for f in fs_dones])
+            np.testing.assert_array_equal(res, [xi+1])

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -225,41 +225,39 @@ class ConfigErrors(unittest.TestCase):
                 assert 'python version' in str(excinfo.value)
 
 class WaitTest(unittest.TestCase):
-    # FIXME: for stability, we should proabbly use the local dummy executor,
-    # but currently the dummy invoker impl does not support wait()
     def setUp(self):
         self.wrenexec = pywren.default_executor()
 
     def test_all_complete(self):
-        def wait_10x_sec_and_plus_one(x):
-            time.sleep(10*x)
+        def wait_x_sec_and_plus_one(x):
+            time.sleep(x)
             return x + 1
 
-        N = 3
+        N = 10
         x = np.arange(N)
 
-        futures = pywren.default_executor().map(wait_10x_sec_and_plus_one, x)
+        futures = pywren.default_executor().map(wait_x_sec_and_plus_one, x)
 
         fs_dones, fs_notdones = pywren.wait(futures,
                                         return_when=pywren.wren.ALL_COMPLETED)
-        res =np.array([f.result() for f in fs_dones])
+        res = np.array([f.result() for f in fs_dones])
         np.testing.assert_array_equal(res, x+1)
 
-    @flaky(max_runs=3)
     def test_any_complete(self):
-        def wait_10x_sec_and_plus_one(x):
-            time.sleep(10*x)
+        def wait_x_sec_and_plus_one(x):
+            time.sleep(x)
             return x + 1
 
-        N = 3
+        N = 10
         x = np.arange(N)
 
-        futures = pywren.default_executor().map(wait_10x_sec_and_plus_one, x)
+        futures = pywren.default_executor().map(wait_x_sec_and_plus_one, x)
 
         fs_notdones = futures
-        for xi in x:
+        while (len(fs_notdones) > 0):
             fs_dones, fs_notdones = pywren.wait(fs_notdones,
                                             return_when=pywren.wren.ANY_COMPLETED,
                                             WAIT_DUR_SEC=1)
-            res =np.array([f.result() for f in fs_dones])
-            np.testing.assert_array_equal(res, [xi+1])
+            self.assertTrue(len(fs_dones) > 0)
+        res = np.array([f.result() for f in futures])
+        np.testing.assert_array_equal(res, x+1)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -224,8 +224,6 @@ class ConfigErrors(unittest.TestCase):
                     pywren.lambda_executor(config)
                 assert 'python version' in str(excinfo.value)
 
-# skipping those tests in CI because of stability concerns
-@pytest.mark.skip                    
 class WaitTest(unittest.TestCase):
     # FIXME: for stability, we should proabbly use the local dummy executor,
     # but currently the dummy invoker impl does not support wait()
@@ -247,6 +245,7 @@ class WaitTest(unittest.TestCase):
         res =np.array([f.result() for f in fs_dones])
         np.testing.assert_array_equal(res, x+1)
 
+    @flaky(max_runs=3)
     def test_any_complete(self):
         def wait_10x_sec_and_plus_one(x):
             time.sleep(10*x)


### PR DESCRIPTION
Support `ANY_COMPLETED` option in `wait()`.
Testing for this feature is a bit tricky: due to the variance of network/lambda performance, the test could fail (although I believe the current setup should pass >95% of the time). Therefore, it will be ignored in CI (using a `skip` marker).
In the future, we should have dummy executor for this test.
@ericmjonas @shivaram 