### PR TITLE
[Issue#77] Print out traceback for exceptions from wrenhandler.py.

### DIFF
--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -525,7 +525,7 @@ class ResponseFuture(object):
 
         while call_status is None:
             time.sleep(self.GET_RESULT_SLEEP_SECS)
-            call_status = get_call_status(self.callset_id, self.call_id, 
+            call_status = get_call_status(self.callset_id, self.call_id,
                                           AWS_S3_BUCKET = self.s3_bucket, 
                                           AWS_S3_PREFIX = self.s3_prefix, 
                                           AWS_REGION = self.aws_region)
@@ -540,7 +540,7 @@ class ResponseFuture(object):
         if call_status['exception'] is not None:
             # the wrenhandler had an exception
             exception_str = call_status['exception']
-            print(call_status.keys())
+            # print(call_status.keys())
             exception_args = call_status['exception_args']
             if exception_args[0] == "WRONGVERSION":
                 if throw_except:
@@ -552,6 +552,7 @@ class ResponseFuture(object):
                 return None
             else:
                 if throw_except:
+                    logger.error("\nRemote " + call_status['exception_traceback'])
                     raise Exception(exception_str, *exception_args)
                 return None
         

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -10,6 +10,7 @@ import uuid
 import json
 import shutil
 import sys
+import traceback
 from threading import Thread
 import signal
 import random
@@ -323,6 +324,7 @@ def generic_handler(event, context_dict):
         # internal runtime exceptions
         response_status['exception'] = str(e)
         response_status['exception_args'] = e.args
+        response_status['exception_traceback'] = traceback.format_exc()
     finally:
 
         s3.meta.client.put_object(Bucket=status_key[0], Key=status_key[1], 


### PR DESCRIPTION
This closes #77 .
With this patch, additional remote traceback information will be printed on host. Example printout:

```
2017-03-09 16:36:03,099 [ERROR] pywren.wren:
Remote Traceback (most recent call last):
  File "/var/task/wrenhandler.py", line 188, in generic_handler
    s3.meta.client.download_file(func_key[0], "name of a file that does not exist", func_filename)
  File "/var/runtime/boto3/s3/inject.py", line 126, in download_file
    extra_args=ExtraArgs, callback=Callback)
  File "/var/runtime/boto3/s3/transfer.py", line 299, in download_file
    future.result()
  File "/var/runtime/s3transfer/futures.py", line 73, in result
    return self._coordinator.result()
  File "/var/runtime/s3transfer/futures.py", line 233, in result
    raise self._exception
ClientError: An error occurred (404) when calling the HeadObject operation: Not Found

Traceback (most recent call last):
  File "test.py", line 12, in <module>
    res = [f.result() for f in futures]
  File "/Users/qifan/repos/pywren/pywren/wren.py", line 557, in result
    raise Exception(exception_str, *exception_args)
Exception: (u'An error occurred (404) when calling the HeadObject operation: Not Found', u'An error occurred (404) when calling the HeadObject operation: Not Found')
```