### PR TITLE
Refactor uses of config in executor.

### DIFF
--- a/pywren/executor.py
+++ b/pywren/executor.py
@@ -32,22 +32,21 @@ class Executor(object):
     """
 
     def __init__(self, aws_region, s3_bucket, s3_prefix,
-                 invoker, config, job_max_runtime):
+                 invoker, runtime_s3_bucket, runtime_s3_key, job_max_runtime):
         self.aws_region = aws_region
         self.s3_bucket = s3_bucket
         self.s3_prefix = s3_prefix
-        self.config = config
 
         self.session = botocore.session.get_session()
         self.invoker = invoker
         self.s3client = self.session.create_client('s3', region_name = aws_region)
         self.job_max_runtime = job_max_runtime
 
-        runtime_bucket = config['runtime']['s3_bucket']
-        runtime_key =  config['runtime']['s3_key']
-        self.runtime_meta_info = runtime.get_runtime_info(runtime_bucket, runtime_key)
+        self.runtime_bucket = runtime_s3_bucket
+        self.runtime_key = runtime_s3_key
+        self.runtime_meta_info = runtime.get_runtime_info(runtime_s3_bucket, runtime_s3_key)
         if not runtime.runtime_key_valid(self.runtime_meta_info):
-            raise Exception("The indicated runtime: s3://{}/{} is not approprite for this python version".format(runtime_bucket, runtime_key))
+            raise Exception("The indicated runtime: s3://{}/{} is not approprite for this python version".format(runtime_s3_bucket, runtime_s3_key))
 
     def create_mod_data(self, mod_paths):
 
@@ -107,8 +106,8 @@ class Executor(object):
                     'data_byte_range' : data_byte_range,
                     'call_id' : call_id,
                     'use_cached_runtime' : use_cached_runtime,
-                    'runtime_s3_bucket' : self.config['runtime']['s3_bucket'],
-                    'runtime_s3_key' : self.config['runtime']['s3_key'],
+                    'runtime_s3_bucket' : self.runtime_bucket,
+                    'runtime_s3_key' : self.runtime_key,
                     'pywren_version' : version.__version__,
                     'runtime_url' : runtime_url }
 

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -36,7 +36,6 @@ def default_executor(**kwargs):
 
 
 def lambda_executor(config=None, job_max_runtime=280):
-
     if config is None:
         config = wrenconfig.default()
 
@@ -44,23 +43,29 @@ def lambda_executor(config=None, job_max_runtime=280):
     FUNCTION_NAME = config['lambda']['function_name']
     S3_BUCKET = config['s3']['bucket']
     S3_PREFIX = config['s3']['pywren_prefix']
+    RUNTIME_S3_BUCKET = config['runtime']['s3_bucket']
+    RUNTIME_S3_KEY = config['runtime']['s3_key']
 
     invoker = invokers.LambdaInvoker(AWS_REGION, FUNCTION_NAME)
-    return Executor(AWS_REGION, S3_BUCKET, S3_PREFIX, invoker, config, 
-                    job_max_runtime)
+    return Executor(AWS_REGION, S3_BUCKET, S3_PREFIX, invoker, 
+                    RUNTIME_S3_BUCKET, RUNTIME_S3_KEY, job_max_runtime)
 
 
-def dummy_executor():
-    config = wrenconfig.default()
+def dummy_executor(config=None, job_max_runtime=100):
+    if config is None:
+        config = wrenconfig.default()
+
     AWS_REGION = config['account']['aws_region']
     S3_BUCKET = config['s3']['bucket']
     S3_PREFIX = config['s3']['pywren_prefix']
+    RUNTIME_S3_BUCKET = config['runtime']['s3_bucket']
+    RUNTIME_S3_KEY = config['runtime']['s3_key']
     invoker = invokers.DummyInvoker()
-    return Executor(AWS_REGION, S3_BUCKET, S3_PREFIX, invoker, config,
-                    100)
+    return Executor(AWS_REGION, S3_BUCKET, S3_PREFIX, invoker,
+                    RUNTIME_S3_BUCKET, RUNTIME_S3_KEY, job_max_runtime)
 
 
-def remote_executor(config= None, job_max_runtime=3600):
+def remote_executor(config=None, job_max_runtime=3600):
     if config is None:
         config = wrenconfig.default()
 
@@ -68,9 +73,11 @@ def remote_executor(config= None, job_max_runtime=3600):
     SQS_QUEUE = config['standalone']['sqs_queue_name']
     S3_BUCKET = config['s3']['bucket']
     S3_PREFIX = config['s3']['pywren_prefix']
+    RUNTIME_S3_BUCKET = config['runtime']['s3_bucket']
+    RUNTIME_S3_KEY = config['runtime']['s3_key']
     invoker = invokers.SQSInvoker(AWS_REGION, SQS_QUEUE)
-    return Executor(AWS_REGION, S3_BUCKET, S3_PREFIX, invoker, config,
-                    job_max_runtime)
+    return Executor(AWS_REGION, S3_BUCKET, S3_PREFIX, invoker,
+                    RUNTIME_S3_BUCKET, RUNTIME_S3_KEY, job_max_runtime)
 
 standalone_executor = remote_executor
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -296,7 +296,7 @@ class RuntimeSharding(unittest.TestCase):
 
         future = wrenexec.call_async(test_func, 7)
         result = future.result()
-        base_runtime_key = wrenexec.config['runtime']['s3_key']
+        base_runtime_key = wrenexec.runtime_key
         self.assertEqual(future.run_status['runtime_s3_key_used'],
                          base_runtime_key)
 
@@ -311,7 +311,7 @@ class RuntimeSharding(unittest.TestCase):
         def test_func(x):
             return x + 1
 
-        base_runtime_key = wrenexec.config['runtime']['s3_key']
+        base_runtime_key = wrenexec.runtime_key
 
         future = wrenexec.call_async(test_func, 7)
         result = future.result()


### PR DESCRIPTION
This PR removes the config variable from the Executor class and makes the config parsing uniform across executor creations. Closes #86 
