### PR TITLE
Stop packaging the entire pywren library in executor.

### DIFF
--- a/pywren/serialize/util.py
+++ b/pywren/serialize/util.py
@@ -22,6 +22,10 @@ def create_mod_data(mod_paths):
             if m.split("/")[-1] == 'pywren':
                 files = glob2.glob(os.path.join(m, "serialize/**/*.py"))
                 files.append(os.path.join(m, "version.py"))
+                init_path = os.path.join(m, "__init__.py")
+                pkg_root = os.path.abspath(os.path.dirname(m))
+                dest_filename = os.path.abspath(init_path)[len(pkg_root)+1:]
+                module_data[dest_filename] = bytes_to_b64str("")
             else:
                 files = glob2.glob(os.path.join(m, "**/*.py"))
             pkg_root = os.path.abspath(os.path.dirname(m))

--- a/pywren/serialize/util.py
+++ b/pywren/serialize/util.py
@@ -21,10 +21,10 @@ def create_mod_data(mod_paths):
         if os.path.isdir(m):
             if m.split("/")[-1] == 'pywren':
                 files = glob2.glob(os.path.join(m, "serialize/**/*.py"))
-                files.append(os.path.join(m, "version.py")
+                files.append(os.path.join(m, "version.py"))
             else:
                 files = glob2.glob(os.path.join(m, "**/*.py"))
-                pkg_root = os.path.abspath(os.path.dirname(m))
+            pkg_root = os.path.abspath(os.path.dirname(m))
         else:
             pkg_root = os.path.abspath(os.path.dirname(m))
             files = [m]

--- a/pywren/serialize/util.py
+++ b/pywren/serialize/util.py
@@ -19,8 +19,12 @@ def create_mod_data(mod_paths):
     # load mod paths
     for m in mod_paths:
         if os.path.isdir(m):
-            files = glob2.glob(os.path.join(m, "**/*.py"))
-            pkg_root = os.path.abspath(os.path.dirname(m))
+            if m.split("/")[-1] == 'pywren':
+                files = glob2.glob(os.path.join(m, "serialize/**/*.py"))
+                files.append(os.path.join(m, "version.py")
+            else:
+                files = glob2.glob(os.path.join(m, "**/*.py"))
+                pkg_root = os.path.abspath(os.path.dirname(m))
         else:
             pkg_root = os.path.abspath(os.path.dirname(m))
             files = [m]


### PR DESCRIPTION
Instead of throwing everything in `pywren/`, this only packages `version`, the serialization modules, and an empty `__init__.py` so that imports work properly.

This is to fix #152. I'm not sure this is right approach, but I wanted to get your thoughts on this.