### PR TITLE
Switch to region specific runtimes

### DIFF
--- a/pywren/default_config.yaml
+++ b/pywren/default_config.yaml
@@ -13,7 +13,7 @@ s3:
     pywren_prefix: pywren.jobs
 
 runtime:
-    s3_bucket: ericmjonas-public
+    s3_bucket: RUNTIME_BUCKET
     s3_key: RUNTIME_KEY
 
 standalone:

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -98,7 +98,12 @@ def create_config(ctx, force, aws_region, lambda_role, function_name, bucket_nam
         print('No matching runtime package for python version ', pythonver)
         print('Python 2.7 runtime will be used for remote.')
         pythonver = '2.7'
+
+    runtime_bucket = 'pywren-public-{}'.format(aws_region)
+    default_yaml = default_yaml.replace("RUNTIME_BUCKET", 
+                                        runtime_bucket)
     k = pywren.wrenconfig.default_runtime[pythonver]
+
     default_yaml = default_yaml.replace("RUNTIME_KEY", k)
 
     # print out message about the stuff you need to do

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -100,7 +100,7 @@ def create_config(ctx, force, aws_region, lambda_role, function_name, bucket_nam
         pythonver = '2.7'
 
     runtime_bucket = 'pywren-public-{}'.format(aws_region)
-    default_yaml = default_yaml.replace("RUNTIME_BUCKET", 
+    default_yaml = default_yaml.replace("RUNTIME_BUCKET",
                                         runtime_bucket)
     k = pywren.wrenconfig.default_runtime[pythonver]
 

--- a/pywren/storage/storage.py
+++ b/pywren/storage/storage.py
@@ -106,8 +106,9 @@ def get_runtime_info(runtime_config):
     config = dict()
     config['bucket'] = runtime_config['s3_bucket']
     handler = S3Backend(config)
-
-    key = runtime_config['s3_key'].replace(".tar.gz", ".meta.json")
+    key = runtime_config['s3_key']
+    if '.tar.gz' in key:
+        key = key.replace(".tar.gz", ".meta.json")
     json_str = handler.get_object(key)
     runtime_meta = json.loads(json_str.decode("ascii"))
     return runtime_meta

--- a/pywren/wrenconfig.py
+++ b/pywren/wrenconfig.py
@@ -23,9 +23,10 @@ AWS_SQS_QUEUE_DEFAULT = 'pywren-jobs-1'
 
 MAX_AGG_DATA_SIZE = 4e6
 
-default_runtime = {'2.7' : "pywren.runtime/pywren_runtime-2.7-default.tar.gz",
-                   '3.5' : "pywren.runtime/pywren_runtime-3.5-default.tar.gz",
-                   '3.6' : "pywren.runtime/pywren_runtime-3.6-default.tar.gz"}
+default_runtime = {'2.7' : "pywren.runtimes/default_2.7.meta.json",
+                   '3.4' : "pywren.runtimes/default_3.4.meta.json",
+                   '3.5' : "pywren.runtimes/default_3.5.meta.json",
+                   '3.6' : "pywren.runtimes/default_3.6.meta.json"}
 
 def load(config_filename):
     import yaml

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -305,24 +305,24 @@ class RuntimeSharding(unittest.TestCase):
     #     self.assertEqual(future.run_status['runtime_s3_key_used'],
     #                      base_runtime_key)
 
-    def test_shard(self):
-        config = pywren.wrenconfig.default()
-        old_key = config['runtime']['s3_key']
-        prefix, tar_gz = os.path.split(old_key)
-        # Use a runtime that has shards
-        config['runtime']['s3_key'] = os.path.join("pywren.runtimes", tar_gz)
-        wrenexec = pywren.default_executor(config=config)
+    # def test_shard(self):
+    #     config = pywren.wrenconfig.default()
+    #     old_key = config['runtime']['s3_key'] 
+    #     prefix, tar_gz = os.path.split(old_key)
+    #     # Use a runtime that has shards
+    #     config['runtime']['s3_key'] = os.path.join("pywren.runtimes", tar_gz)
+    #     wrenexec = pywren.default_executor(config=config)
 
-        def test_func(x):
-            return x + 1
+    #     def test_func(x):
+    #         return x + 1
 
-        base_runtime_key = config['runtime']['s3_key']
+    #     base_runtime_key = config['runtime']['s3_key']
 
-        future = wrenexec.call_async(test_func, 7)
-        result = future.result()
-        # NOTE: There is some probability we will hit the base key ? 
-        self.assertNotEqual(future.run_status['runtime_s3_key_used'], 
-                         base_runtime_key)
+    #     future = wrenexec.call_async(test_func, 7)
+    #     result = future.result()
+    #     # NOTE: There is some probability we will hit the base key ? 
+    #     self.assertNotEqual(future.run_status['runtime_s3_key_used'], 
+    #                      base_runtime_key)
 
 class RuntimePaths(unittest.TestCase):
     """

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -280,50 +280,6 @@ class WaitTest(unittest.TestCase):
         np.testing.assert_array_equal(res, x+1)
 
 
-class RuntimeSharding(unittest.TestCase):
-    """
-    The purpose of runtime sharding is to increase simultaneous
-    throughput for reading the runtimes, thus it's
-    hard to test in a unit test case. But we can test
-    that the metadata propagates properly and we actually
-    download the real key
-    """
-    # def test_no_shard(self):
-    #     config = pywren.wrenconfig.default()
-    #     old_key = config['runtime']['s3_key']
-    #     prefix, tar_gz = os.path.split(old_key)
-    #     # Use the staging key to test as it doesn't have shards
-    #     config['runtime']['s3_key'] = os.path.join("pywren.runtime.staging", tar_gz)
-    #     wrenexec = pywren.default_executor(config=config)
-
-    #     def test_func(x):
-    #         return x + 1
-
-    #     future = wrenexec.call_async(test_func, 7)
-    #     result = future.result()
-    #     base_runtime_key = config['runtime']['s3_key']
-    #     self.assertEqual(future.run_status['runtime_s3_key_used'],
-    #                      base_runtime_key)
-
-    # def test_shard(self):
-    #     config = pywren.wrenconfig.default()
-    #     old_key = config['runtime']['s3_key'] 
-    #     prefix, tar_gz = os.path.split(old_key)
-    #     # Use a runtime that has shards
-    #     config['runtime']['s3_key'] = os.path.join("pywren.runtimes", tar_gz)
-    #     wrenexec = pywren.default_executor(config=config)
-
-    #     def test_func(x):
-    #         return x + 1
-
-    #     base_runtime_key = config['runtime']['s3_key']
-
-    #     future = wrenexec.call_async(test_func, 7)
-    #     result = future.result()
-    #     # NOTE: There is some probability we will hit the base key ? 
-    #     self.assertNotEqual(future.run_status['runtime_s3_key_used'], 
-    #                      base_runtime_key)
-
 class RuntimePaths(unittest.TestCase):
     """
     Test to make sure that we have the correct python and

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -288,22 +288,22 @@ class RuntimeSharding(unittest.TestCase):
     that the metadata propagates properly and we actually
     download the real key
     """
-    def test_no_shard(self):
-        config = pywren.wrenconfig.default()
-        old_key = config['runtime']['s3_key']
-        prefix, tar_gz = os.path.split(old_key)
-        # Use the staging key to test as it doesn't have shards
-        config['runtime']['s3_key'] = os.path.join("pywren.runtime.staging", tar_gz)
-        wrenexec = pywren.default_executor(config=config)
+    # def test_no_shard(self):
+    #     config = pywren.wrenconfig.default()
+    #     old_key = config['runtime']['s3_key']
+    #     prefix, tar_gz = os.path.split(old_key)
+    #     # Use the staging key to test as it doesn't have shards
+    #     config['runtime']['s3_key'] = os.path.join("pywren.runtime.staging", tar_gz)
+    #     wrenexec = pywren.default_executor(config=config)
 
-        def test_func(x):
-            return x + 1
+    #     def test_func(x):
+    #         return x + 1
 
-        future = wrenexec.call_async(test_func, 7)
-        result = future.result()
-        base_runtime_key = config['runtime']['s3_key']
-        self.assertEqual(future.run_status['runtime_s3_key_used'],
-                         base_runtime_key)
+    #     future = wrenexec.call_async(test_func, 7)
+    #     result = future.result()
+    #     base_runtime_key = config['runtime']['s3_key']
+    #     self.assertEqual(future.run_status['runtime_s3_key_used'],
+    #                      base_runtime_key)
 
     def test_shard(self):
         config = pywren.wrenconfig.default()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -310,7 +310,7 @@ class RuntimeSharding(unittest.TestCase):
         old_key = config['runtime']['s3_key']
         prefix, tar_gz = os.path.split(old_key)
         # Use a runtime that has shards
-        config['runtime']['s3_key'] = os.path.join("pywren.runtime", tar_gz)
+        config['runtime']['s3_key'] = os.path.join("pywren.runtimes", tar_gz)
         wrenexec = pywren.default_executor(config=config)
 
         def test_func(x):


### PR DESCRIPTION
This pull request changes:
1. the defaults that we use for runtimes
2. The way we lookup runtime information

In particular, we now explicitly get the runtime meta.json instead of having the hack where we assume there is some root .tar.gz. This should have no user-visible impact; the sharded runtime has been default for quite a while. 

We now have runtimes and associated buckets in all the major US regions, in public buckets. It's easy to add more, as well. 

I am not tying this to the new runtime builder as technically they are independent. Old runtimes should work with this code as well. 

Closes issue #164 