### PR TITLE
Issue#160 Straggler due to list-after-write consistency

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -78,7 +78,7 @@ enable=
 # --disable=W"
 
 # These are errors still not addressed in PyWren.
-disable=invalid-name,missing-docstring,too-many-branches,too-many-arguments,too-many-locals,logging-format-interpolation,too-many-public-methods,too-few-public-methods,too-many-instance-attributes,bare-except,broad-except,protected-access,unidiomatic-typecheck,too-many-return-statements,too-many-statements,locally-disabled,len-as-condition,no-else-return
+disable=invalid-name,missing-docstring,too-many-branches,too-many-arguments,too-many-locals,logging-format-interpolation,too-many-public-methods,too-few-public-methods,too-many-instance-attributes,bare-except,broad-except,protected-access,unidiomatic-typecheck,too-many-return-statements,too-many-statements,locally-disabled,len-as-condition,no-else-return,superfluous-parens
 
 [REPORTS]
 

--- a/pywren/wait.py
+++ b/pywren/wait.py
@@ -115,7 +115,7 @@ def _wait(fs, THREADPOOL_SIZE):
         callids_done.update(callids_found)
 
         # break if not all N tasks completed
-        if (len(fs_found) < len(fs_samples)):
+        if (len(callids_found) < len(fs_samples)):
             break
         # calculate new still_not_done_futures
         still_not_done_futures = [f for f in not_done_futures if (f.call_id not in callids_done)]

--- a/pywren/wait.py
+++ b/pywren/wait.py
@@ -99,7 +99,7 @@ def _wait(fs, THREADPOOL_SIZE):
     num_samples = 4
     still_not_done_futures = [f for f in not_done_futures if (f.call_id not in callids_done)]
     def fetch_status(f):
-        return storage_handler.get_callset_status(f.callset_id, f.call_id)
+        return storage_handler.get_call_status(f.callset_id, f.call_id)
 
     pool = ThreadPool(num_samples)
     # repeat util all futures are done

--- a/pywren/wait.py
+++ b/pywren/wait.py
@@ -105,7 +105,7 @@ def _wait(fs, THREADPOOL_SIZE):
     # repeat util all futures are done
     while still_not_done_futures:
         fs_samples = random.sample(still_not_done_futures,
-                                  min(num_samples, len(still_not_done_futures)))
+                                   min(num_samples, len(still_not_done_futures)))
         fs_statuses = pool.map(fetch_status, fs_samples)
 
         callids_found = [fs_samples[i].call_id for i in range(len(fs_samples))


### PR DESCRIPTION
In wait(), we signal the completion of tasks by probing status files. Because S3 does not provide list-after-write consistency (which might also apply to other storage backend). List() can be only used as an optimization but not a timely way to signal completion. Thus, our strategy is to:
    1) do list()
    2) use get() to signal N tasks that do not show up in 1)
    3) repeat 2) if all N tasks completed, otherwise stop
Note: a small N is probably preferred here. N is set to 4.
#160 