### PR TITLE
Lambda toobig seatbelts

### DIFF
--- a/pywren/future.py
+++ b/pywren/future.py
@@ -137,7 +137,7 @@ class ResponseFuture(object):
         if call_status['exception'] is not None:
             # the wrenhandler had an exception
             exception_str = call_status['exception']
-            print(call_status)
+
             exception_args = call_status['exception_args']
             if exception_args[0] == "WRONGVERSION":
                 if throw_except:

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -101,10 +101,9 @@ def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
             fileobj=wrenutil.WrappedStreamingBody(res['Body'],
                                                   res['ContentLength']))
         condatar.extractall(runtime_etag_dir)
-    except OSerror as e:
+    except IOError as e: # this is an OSError in python3 
         # do the cleanup
         shutil.rmtree(runtime_etag_dir, True)
-
         if e.args[0] == 28:
 
             raise Exception("RUNTIME_TOO_BIG",
@@ -115,6 +114,9 @@ def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
         # do the cleanup
         shutil.rmtree(runtime_etag_dir, True)
         raise Exception("RUNTIME_READ_ERROR", str(e))
+    except:
+        shutil.rmtree(runtime_etag_dir, True)
+        raise
 
     # final operation
     os.symlink(expected_target, CONDA_RUNTIME_DIR)

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 PROCESS_STDOUT_SLEEP_SECS = 2
 
+TMP_MIN_FREE_SPACE_BYTES = 10000000
+
 def get_key_size(s3client, bucket, key):
     try:
         a = s3client.head_object(Bucket=bucket, Key=key)
@@ -41,6 +43,13 @@ def get_key_size(s3client, bucket, key):
             return None
         else:
             raise e
+
+def free_disk_space(dirname):
+    """
+    Returns the number of free bytes on the mount point containing DIRNAME
+    """
+    s = os.statvfs(dirname)
+    return s.f_bsize * s.f_bavail
 
 def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
     """
@@ -87,8 +96,12 @@ def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
     condatar = tarfile.open(
         mode="r:gz",
         fileobj=wrenutil.WrappedStreamingBody(res['Body'], res['ContentLength']))
-
-    condatar.extractall(runtime_etag_dir)
+    try:
+        condatar.extractall(runtime_etag_dir)
+    except:
+        shutil.rmtree(runtime_etag_dir, True)
+        raise Exception("RUNTIME_TOO_BIG",
+                        "Ran out of space when untarring runtime")
 
     # final operation
     os.symlink(expected_target, CONDA_RUNTIME_DIR)
@@ -174,16 +187,26 @@ def generic_handler(event, context_dict):
         response_status['output_key'] = output_key
         response_status['status_key'] = status_key
 
-        KS = get_key_size(s3_client, s3_bucket, data_key)
-        #logger.info("bucket=", s3_bucket, "key=", data_key,  "status: ", KS, "bytes" )
-        while KS is None:
+        data_key_size = get_key_size(s3_client, s3_bucket, data_key)
+        #logger.info("bucket=", s3_bucket, "key=", data_key,  "status: ", data_key_size, "bytes" )
+        while data_key_size is None:
             logger.warning("WARNING COULD NOT GET FIRST KEY")
 
-            KS = get_key_size(s3_client, s3_bucket, data_key)
+            data_key_size = get_key_size(s3_client, s3_bucket, data_key)
         if not event['use_cached_runtime']:
             subprocess.check_output("rm -Rf {}/*".format(RUNTIME_LOC), shell=True)
+        func_key_size = get_key_size(s3_client, s3_bucket, func_key)
 
-
+        free_disk_bytes = free_disk_space("/tmp")
+        if (func_key_size + data_key_size) > (free_disk_bytes - TMP_MIN_FREE_SPACE_BYTES):
+            raise Exception("ARGS_TOO_BIG",
+                            "data + func too large {:3.1f} MB (data={:3.1f}MB, func={:3.1f}MB)," \
+                            " free space on worker is {:3.1f} MB, " \
+                            " need at least {:3.1f} MB of free space headroom to run"\
+                            .format((func_key_size + data_key_size)/1e6,
+                                    data_key_size/1e6, func_key_size/1e6,
+                                    free_disk_bytes/1e6,
+                                    TMP_MIN_FREE_SPACE_BYTES/1e6))
         # get the input and save to disk
         # FIXME here is we where we would attach the "canceled" metadata
         s3_transfer.download_file(s3_bucket, func_key, func_filename)

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -101,7 +101,7 @@ def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
             fileobj=wrenutil.WrappedStreamingBody(res['Body'],
                                                   res['ContentLength']))
         condatar.extractall(runtime_etag_dir)
-    except IOError as e: # this is an OSError in python3 
+    except IOError as e: # this is an OSError in python3
         # do the cleanup
         shutil.rmtree(runtime_etag_dir, True)
         if e.args[0] == 28:

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -69,7 +69,8 @@ def test_too_big_runtime():
 
     too_big_config = pywren.wrenconfig.default()
     too_big_config['runtime']['s3_bucket'] = 'pywren-public-us-west-2'
-    too_big_config['runtime']['s3_key'] = "pywren.runtimes/too_big_do_not_use_2.7.tar.gz"
+    ver_str = "{}.{}".format(sys.version_info[0], sys.version_info[1])
+    too_big_config['runtime']['s3_key'] = "pywren.runtimes/too_big_do_not_use_{}.tar.gz".format(ver_str)
 
 
     default_config = pywren.wrenconfig.default()

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -49,4 +49,83 @@ class Timeout(unittest.TestCase):
         fut = self.wrenexec.call_async(take_forever, None)
         res = fut.result(throw_except=False)
 
-            
+@lamb            
+def test_too_big_runtime():
+    """
+    Sometimes we accidentally build a runtime that's too big. 
+    When this happens, the runtime was leaving behind crap
+    and we could never test the runtime again. 
+    This tests if we now return a sane exception and can re-run code. 
+
+    There are problems with this test. It is:
+    1. lambda only 
+    2. depends on lambda having a 512 MB limit. When that is raised someday, 
+    this test will always pass. 
+    3. Is flaky, because it might be the case that we get _new_
+    workers on the next invocation to map that don't have the left-behind
+    crap. 
+    """
+
+
+    too_big_config = pywren.wrenconfig.default()
+    too_big_config['runtime']['s3_bucket'] = 'pywren-public-us-west-2'
+    too_big_config['runtime']['s3_key'] = "pywren.runtimes/too_big_do_not_use_2.7.tar.gz"
+
+
+    default_config = pywren.wrenconfig.default()
+
+
+    wrenexec_toobig = pywren.default_executor(config=too_big_config)
+    wrenexec = pywren.default_executor(config=default_config)
+
+
+    def simple_foo(x):
+        return x
+    MAP_N = 10
+
+    futures = wrenexec_toobig.map(simple_foo, range(MAP_N))
+    for f in futures:
+        with pytest.raises(Exception) as excinfo:
+            f.result()
+        assert excinfo.value.args[1] == 'RUNTIME_TOO_BIG'
+
+    # these ones should work
+    futures = wrenexec.map(simple_foo, range(MAP_N))
+    for f in futures:
+        f.result()
+
+@lamb   
+def test_too_big_args():
+    """
+    This is a test where the data is too large
+    to fit on the temporary space on the lambdas. 
+    Again, somewhat brittle, lambda specific, and will
+    break when they change the available /tmp space limits. 
+
+    Note this test takes a long time because of the large amount of
+    data that must be uploaded. 
+    """
+
+    wrenexec = pywren.default_executor()
+
+    DATA_MB = 200
+
+    data = "0"*(DATA_MB*1000000)
+
+    def simple_foo(x):
+        return 1.0
+    
+    
+    f = wrenexec.call_async(simple_foo, data)
+    with pytest.raises(Exception) as excinfo:
+        f.result()
+    assert excinfo.value.args[1] == 'ARGS_TOO_BIG'
+
+    def simple_foo_2(x):
+        #capture data in the closure
+        return len(data)
+
+    f = wrenexec.call_async(simple_foo_2, None)
+    with pytest.raises(Exception) as excinfo:
+        f.result()
+    assert excinfo.value.args[1] == 'ARGS_TOO_BIG'


### PR DESCRIPTION
This is a series of fixes to handle:
1. if the runtime is too big, communicate to the user and execute proper cleanup on the worker so the worker isn't forever broken. (issue #105)

2. If downloading the func or the data is too large for the remaining space, error as well. 