### PR TITLE
Make pywren.wait() args available in pywren module.

### DIFF
--- a/pywren/__init__.py
+++ b/pywren/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from pywren import wrenlogging
 from pywren.wren import * # pylint: disable=wildcard-import
+from pywren.wait import ALL_COMPLETED, ANY_COMPLETED, ALWAYS
 
 if "PYWREN_LOGLEVEL" in os.environ:
     log_level = os.environ['PYWREN_LOGLEVEL']
@@ -15,4 +16,3 @@ if "PYWREN_LOGLEVEL" in os.environ:
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-from pywren.wait import ALL_COMPLETED, ANY_COMPLETED, ALWAYS

--- a/pywren/__init__.py
+++ b/pywren/__init__.py
@@ -14,3 +14,5 @@ if "PYWREN_LOGLEVEL" in os.environ:
 
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+from pywren.wait import ALL_COMPLETED, ANY_COMPLETED, ALWAYS


### PR DESCRIPTION
Fix #174
```
>>> import pywren
>>> pywren.ALL_COMPLETED
1
```

Before we had to do 

```
>>> import pywren
>>> pywren.wait.ALL_COMPLETED
1
```