### PR TITLE
Migrate s3io to jobrunner

### DIFF
--- a/pywren/executor.py
+++ b/pywren/executor.py
@@ -206,13 +206,8 @@ class Executor(object):
                         mod_paths.remove(mod_path)
 
         module_data = create_mod_data(mod_paths)
-        func_str_encoded = func_str
-        #debug_foo = {'func' : func_str_encoded,
-        #             'module_data' : module_data}
-
-        #pickle.dump(debug_foo, open("/tmp/py35.debug.pickle", 'wb'))
         ### Create func and upload
-        func_module_str = pickle.dumps({'func' : func_str_encoded,
+        func_module_str = pickle.dumps({'func' : func_str,
                                         'module_data' : module_data}, -1)
         host_job_meta['func_module_str_len'] = len(func_module_str)
 

--- a/pywren/executor.py
+++ b/pywren/executor.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import json
 import logging
 import random
 import time
 from multiprocessing.pool import ThreadPool
+from six.moves import cPickle as pickle
 
 import boto3
 
@@ -206,14 +206,14 @@ class Executor(object):
                         mod_paths.remove(mod_path)
 
         module_data = create_mod_data(mod_paths)
-        func_str_encoded = wrenutil.bytes_to_b64str(func_str)
+        func_str_encoded = func_str
         #debug_foo = {'func' : func_str_encoded,
         #             'module_data' : module_data}
 
         #pickle.dump(debug_foo, open("/tmp/py35.debug.pickle", 'wb'))
         ### Create func and upload
-        func_module_str = json.dumps({'func' : func_str_encoded,
-                                      'module_data' : module_data})
+        func_module_str = pickle.dumps({'func' : func_str_encoded,
+                                        'module_data' : module_data}, -1)
         host_job_meta['func_module_str_len'] = len(func_module_str)
 
         func_upload_time = time.time()

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -4,12 +4,20 @@ import base64
 import json
 import sys
 import traceback
+import boto3
+from pywren.wrenutil import WrappedStreamingBody
 
 from six.moves import cPickle as pickle
 from tblib import pickling_support
 
 pickling_support.install()
 
+# def s3_url_parse(url):
+#     if url[:5] != "s3://":
+#         raise Exception("improperly formatted s3 url: {}".format(url))
+#     bucket, key = url[5:].split("/", 1)
+#     return bucket, key
+    
 def b64str_to_bytes(str_data):
     str_ascii = str_data.encode('ascii')
     byte_data = base64.b64decode(str_ascii)
@@ -19,15 +27,38 @@ try:
     func_filename = sys.argv[1]
     data_filename = sys.argv[2]
     out_filename = sys.argv[3]
+    jobrunner_config_filename = sys.argv[4]
+
     # initial output file in case job fails
     pickle.dump({'result' : None,
                  'success' : False},
                 open(out_filename, 'wb'), -1)
+    jobrunner_config = json.load(open(jobrunner_config_filename, 
+                                      'rb'))
+
+
+    # FIXME someday switch to storage handler
+    # download the func data into memory
+    s3_client = boto3.client("s3")
+    func_bucket, func_key = jobrunner_config['func_bucket'], jobrunner_config['func_key']
+    data_bucket, data_key = jobrunner_config['data_bucket'], jobrunner_config['data_key']
+
+    data_byte_range = jobrunner_config['data_byte_range']
+    func_obj_stream = s3_client.get_object(Bucket=func_bucket, Key=func_key)
+    loaded_func_json = json.load(func_obj_stream['Body'])
+    loaded_func = pickle.loads(b64str_to_bytes(loaded_func_json['func']))
+
+    extra_get_args = {}
+    if data_byte_range is not None:
+        range_str = 'bytes={}-{}'.format(*data_byte_range)
+        extra_get_args['Range'] = range_str
+    data_obj_stream = s3_client.get_object(Bucket=data_bucket, 
+                                           Key=data_key, **extra_get_args)
+    # FIXME make this streaming
+    loaded_data = pickle.loads(data_obj_stream['Body'].read())
 
     print("loading", func_filename, data_filename, out_filename)
-    func_b64 = b64str_to_bytes(json.load(open(func_filename, 'r'))['func'])
-    loaded_func = pickle.loads(func_b64)
-    loaded_data = pickle.load(open(data_filename, 'rb'))
+
     print("loaded")
     y = loaded_func(loaded_data)
     print("success")

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -33,7 +33,7 @@ try:
                  'success' : False},
                 open(out_filename, 'wb'), -1)
     jobrunner_config = json.load(open(jobrunner_config_filename,
-                                      'rb'))
+                                      'r'))
 
 
     # FIXME someday switch to storage handler

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -6,7 +6,6 @@ import json
 import sys
 import boto3
 
-
 from six.moves import cPickle as pickle
 from tblib import pickling_support
 
@@ -48,9 +47,10 @@ try:
 
     # save modules, before we unpickle actual function
     PYTHON_MODULE_PATH = jobrunner_config['python_module_path']
-    # clean up for modules
+
     shutil.rmtree(PYTHON_MODULE_PATH, True) # delete old modules
     os.mkdir(PYTHON_MODULE_PATH)
+    sys.path.append(PYTHON_MODULE_PATH)
 
     for m_filename, m_data in loaded_func_all['module_data'].items():
         m_path = os.path.dirname(m_filename)

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
-
+import os
 import base64
 import json
 import sys
 import traceback
 import boto3
-import os
+
 
 from six.moves import cPickle as pickle
 from tblib import pickling_support
@@ -17,7 +17,7 @@ pickling_support.install()
 #         raise Exception("improperly formatted s3 url: {}".format(url))
 #     bucket, key = url[5:].split("/", 1)
 #     return bucket, key
-    
+
 def b64str_to_bytes(str_data):
     str_ascii = str_data.encode('ascii')
     byte_data = base64.b64decode(str_ascii)
@@ -32,10 +32,10 @@ try:
     pickle.dump({'result' : None,
                  'success' : False},
                 open(out_filename, 'wb'), -1)
-    jobrunner_config = json.load(open(jobrunner_config_filename, 
+    jobrunner_config = json.load(open(jobrunner_config_filename,
                                       'rb'))
 
-    
+
     # FIXME someday switch to storage handler
     # download the func data into memory
     s3_client = boto3.client("s3")
@@ -47,7 +47,7 @@ try:
     loaded_func_json = json.load(func_obj_stream['Body'])
 
     # save modules, before we unpickle actual function
-    PYTHON_MODULE_PATH=jobrunner_config['python_module_path']
+    PYTHON_MODULE_PATH = jobrunner_config['python_module_path']
     for m_filename, m_data in loaded_func_json['module_data'].items():
         m_path = os.path.dirname(m_filename)
 
@@ -78,7 +78,7 @@ try:
     if data_byte_range is not None:
         range_str = 'bytes={}-{}'.format(*data_byte_range)
         extra_get_args['Range'] = range_str
-    data_obj_stream = s3_client.get_object(Bucket=data_bucket, 
+    data_obj_stream = s3_client.get_object(Bucket=data_bucket,
                                            Key=data_key, **extra_get_args)
     # FIXME make this streaming
     loaded_data = pickle.loads(data_obj_stream['Body'].read())

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -44,11 +44,11 @@ try:
 
     data_byte_range = jobrunner_config['data_byte_range']
     func_obj_stream = s3_client.get_object(Bucket=func_bucket, Key=func_key)
-    loaded_func_json = json.load(func_obj_stream['Body'])
+    loaded_func_all = pickle.loads(func_obj_stream['Body'].read())
 
     # save modules, before we unpickle actual function
     PYTHON_MODULE_PATH = jobrunner_config['python_module_path']
-    for m_filename, m_data in loaded_func_json['module_data'].items():
+    for m_filename, m_data in loaded_func_all['module_data'].items():
         m_path = os.path.dirname(m_filename)
 
         if len(m_path) > 0 and m_path[0] == "/":
@@ -72,7 +72,7 @@ try:
 
 
     # now unpickle function; it will expect modules to be there
-    loaded_func = pickle.loads(b64str_to_bytes(loaded_func_json['func']))
+    loaded_func = pickle.loads(loaded_func_all['func'])
 
     extra_get_args = {}
     if data_byte_range is not None:

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -12,11 +12,6 @@ from tblib import pickling_support
 
 pickling_support.install()
 
-# def s3_url_parse(url):
-#     if url[:5] != "s3://":
-#         raise Exception("improperly formatted s3 url: {}".format(url))
-#     bucket, key = url[5:].split("/", 1)
-#     return bucket, key
 
 def b64str_to_bytes(str_data):
     str_ascii = str_data.encode('ascii')

--- a/pywren/storage/storage_utils.py
+++ b/pywren/storage/storage_utils.py
@@ -2,7 +2,7 @@ import os
 
 from .exceptions import StorageConfigMismatchError
 
-func_key_suffix = "func.json"
+func_key_suffix = "func.pickle"
 agg_data_key_suffix = "aggdata.pickle"
 data_key_suffix = "data.pickle"
 output_key_suffix = "output.pickle"

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -245,7 +245,7 @@ def generic_handler(event, context_dict):
         logger.info("data data download complete, took {:3.2f} sec".format(data_download_time))
         response_status['data_download_time'] = data_download_time
 
-        d = json.load(open(func_filename, 'r'))
+        # d = json.load(open(func_filename, 'r'))
         # clean up for modules
         shutil.rmtree(PYTHON_MODULE_PATH, True) # delete old modules
         os.mkdir(PYTHON_MODULE_PATH)
@@ -297,15 +297,15 @@ def generic_handler(event, context_dict):
 
         # pass a full json blob
         jobrunner_config_filename = "/tmp/jobrunner.config.json"
-        jobrunner_config = {'func_bucket' : s3_bucket, 
-                            'func_key' : func_key, 
-                            'data_bucket' : s3_bucket, 
-                            'data_key' : data_key, 
-                            'data_byte_range' : data_byte_range, 
+        jobrunner_config = {'func_bucket' : s3_bucket,
+                            'func_key' : func_key,
+                            'data_bucket' : s3_bucket,
+                            'data_key' : data_key,
+                            'data_byte_range' : data_byte_range,
                             'python_module_path' : PYTHON_MODULE_PATH}
         with open(jobrunner_config_filename, 'w') as jobrunner_fid:
             json.dump(jobrunner_config, jobrunner_fid)
- 
+
         cmdstr = "{} {} {} {}".format(CONDA_PYTHON_RUNTIME,
                                       jobrunner_path,
                                       jobrunner_config_filename,

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -221,7 +221,7 @@ def generic_handler(event, context_dict):
         jobrunner_path = os.path.join(cwd, "jobrunner.py")
 
         extra_env = event.get('extra_env', {})
-        extra_env['PYTHONPATH'] = "{}:{}".format(os.getcwd(), PYTHON_MODULE_PATH)
+        extra_env['PYTHONPATH'] = "{}".format(os.getcwd())
 
         call_id = event['call_id']
         callset_id = event['callset_id']

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -27,13 +27,11 @@ else:
 PYTHON_MODULE_PATH = "/tmp/pymodules"
 CONDA_RUNTIME_DIR = "/tmp/condaruntime"
 RUNTIME_LOC = "/tmp/runtimes"
+JOBRUNNER_CONFIG_FILENAME = "/tmp/jobrunner.config.json"
 
 logger = logging.getLogger(__name__)
 
 PROCESS_STDOUT_SLEEP_SECS = 2
-
-# Make sure we have at least 10 MB
-TMP_MIN_FREE_SPACE_BYTES = 10000000
 
 def get_key_size(s3client, bucket, key):
     try:
@@ -163,7 +161,6 @@ def generic_handler(event, context_dict):
             raise NotImplementedError(("Using {} as storage backend is not supported " +
                                        "yet.").format(event['storage_config']['storage_backend']))
         s3_client = boto3.client("s3")
-        s3_transfer = boto3.s3.transfer.S3Transfer(s3_client)
         s3_bucket = event['storage_config']['backend_config']['bucket']
 
         logger.info("invocation started")
@@ -181,8 +178,6 @@ def generic_handler(event, context_dict):
 
         start_time = time.time()
         response_status['start_time'] = start_time
-
-        output_filename = "/tmp/output.pickle"
 
         runtime_s3_bucket = event['runtime']['s3_bucket']
         runtime_s3_key = event['runtime']['s3_key']
@@ -209,41 +204,10 @@ def generic_handler(event, context_dict):
             data_key_size = get_key_size(s3_client, s3_bucket, data_key)
         if not event['use_cached_runtime']:
             subprocess.check_output("rm -Rf {}/*".format(RUNTIME_LOC), shell=True)
-        func_key_size = get_key_size(s3_client, s3_bucket, func_key)
+
 
         free_disk_bytes = free_disk_space("/tmp")
-
-        # if (func_key_size + data_key_size) > (free_disk_bytes - TMP_MIN_FREE_SPACE_BYTES):
-        #     raise Exception("ARGS_TOO_BIG",
-        #                     "data + func too large {:3.1f} MB (data={:3.1f}MB, func={:3.1f}MB)," \
-        #                     " free space on worker is {:3.1f} MB, " \
-        #                     " need at least {:3.1f} MB of free space headroom to run"\
-        #                     .format((func_key_size + data_key_size)/1e6,
-        #                             data_key_size/1e6, func_key_size/1e6,
-        #                             free_disk_bytes/1e6,
-        #                             TMP_MIN_FREE_SPACE_BYTES/1e6))
-        # get the input and save to disk
-        # FIXME here is we where we would attach the "canceled" metadata
-        #s3_transfer.download_file(s3_bucket, func_key, func_filename)
-        #func_download_time = time.time() - start_time
-        #response_status['func_download_time'] = func_download_time
-
-        #logger.info("func download complete, took {:3.2f} sec".format(func_download_time))
-
-        # if data_byte_range is None:
-        #     s3_transfer.download_file(s3_bucket, data_key, data_filename)
-        # else:
-        #     range_str = 'bytes={}-{}'.format(*data_byte_range)
-        #     dres = s3_client.get_object(Bucket=s3_bucket, Key=data_key,
-        #                                 Range=range_str)
-        #     data_fid = open(data_filename, 'wb')
-        #     data_fid.write(dres['Body'].read())
-        #     data_fid.close()
-
-        # data_download_time = time.time() - start_time
-        # logger.info("data data download complete, took {:3.2f} sec".format(data_download_time))
-        # response_status['data_download_time'] = data_download_time
-
+        response_status['free_disk_bytes'] = free_disk_bytes
         # clean up for modules
         shutil.rmtree(PYTHON_MODULE_PATH, True) # delete old modules
         os.mkdir(PYTHON_MODULE_PATH)
@@ -271,20 +235,22 @@ def generic_handler(event, context_dict):
         CONDA_PYTHON_RUNTIME = os.path.join(CONDA_PYTHON_PATH, "python")
 
         # pass a full json blob
-        jobrunner_config_filename = "/tmp/jobrunner.config.json"
+
         jobrunner_config = {'func_bucket' : s3_bucket,
                             'func_key' : func_key,
                             'data_bucket' : s3_bucket,
                             'data_key' : data_key,
                             'data_byte_range' : data_byte_range,
-                            'python_module_path' : PYTHON_MODULE_PATH}
-        with open(jobrunner_config_filename, 'w') as jobrunner_fid:
+                            'python_module_path' : PYTHON_MODULE_PATH,
+                            'output_bucket' : s3_bucket,
+                            'output_key' : output_key}
+
+        with open(JOBRUNNER_CONFIG_FILENAME, 'w') as jobrunner_fid:
             json.dump(jobrunner_config, jobrunner_fid)
 
-        cmdstr = "{} {} {} {}".format(CONDA_PYTHON_RUNTIME,
-                                      jobrunner_path,
-                                      jobrunner_config_filename,
-                                      output_filename)
+        cmdstr = "{} {} {}".format(CONDA_PYTHON_RUNTIME,
+                                   jobrunner_path,
+                                   JOBRUNNER_CONFIG_FILENAME)
 
         setup_time = time.time()
         response_status['setup_time'] = setup_time - start_time
@@ -332,10 +298,6 @@ def generic_handler(event, context_dict):
 
 
         logger.info("command execution finished")
-
-        s3_transfer.upload_file(output_filename, s3_bucket,
-                                output_key)
-        logger.debug("output uploaded to %s %s", s3_bucket, output_key)
 
         end_time = time.time()
 

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -256,7 +256,6 @@ def generic_handler(event, context_dict):
             if len(m_path) > 0 and m_path[0] == "/":
                 m_path = m_path[1:]
             to_make = os.path.join(PYTHON_MODULE_PATH, m_path)
-            #print "to_make=", to_make, "m_path=", m_path
             try:
                 os.makedirs(to_make)
             except OSError as e:
@@ -295,11 +294,22 @@ def generic_handler(event, context_dict):
         CONDA_PYTHON_PATH = "/tmp/condaruntime/bin"
         CONDA_PYTHON_RUNTIME = os.path.join(CONDA_PYTHON_PATH, "python")
 
-        cmdstr = "{} {} {} {} {}".format(CONDA_PYTHON_RUNTIME,
-                                         jobrunner_path,
-                                         func_filename,
-                                         data_filename,
-                                         output_filename)
+        # pass a full json blob
+        jobrunner_config_filename = "/tmp/jobrunner.config.json"
+        jobrunner_config = {'func_bucket' : s3_bucket, 
+                            'func_key' : func_key, 
+                            'data_bucket' : s3_bucket, 
+                            'data_key' : data_key, 
+                            'data_byte_range' : data_byte_range}
+        with open(jobrunner_config_filename, 'w') as jobrunner_fid:
+            json.dump(jobrunner_config, jobrunner_fid)
+ 
+        cmdstr = "{} {} {} {} {} {}".format(CONDA_PYTHON_RUNTIME,
+                                               jobrunner_path,
+                                               func_filename,
+                                               data_filename,
+                                               output_filename, 
+                                               jobrunner_config_filename)
 
         setup_time = time.time()
         response_status['setup_time'] = setup_time - start_time

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -182,8 +182,6 @@ def generic_handler(event, context_dict):
         start_time = time.time()
         response_status['start_time'] = start_time
 
-        func_filename = "/tmp/func.pickle"
-        data_filename = "/tmp/data.pickle"
         output_filename = "/tmp/output.pickle"
 
         runtime_s3_bucket = event['runtime']['s3_bucket']
@@ -214,64 +212,41 @@ def generic_handler(event, context_dict):
         func_key_size = get_key_size(s3_client, s3_bucket, func_key)
 
         free_disk_bytes = free_disk_space("/tmp")
-        if (func_key_size + data_key_size) > (free_disk_bytes - TMP_MIN_FREE_SPACE_BYTES):
-            raise Exception("ARGS_TOO_BIG",
-                            "data + func too large {:3.1f} MB (data={:3.1f}MB, func={:3.1f}MB)," \
-                            " free space on worker is {:3.1f} MB, " \
-                            " need at least {:3.1f} MB of free space headroom to run"\
-                            .format((func_key_size + data_key_size)/1e6,
-                                    data_key_size/1e6, func_key_size/1e6,
-                                    free_disk_bytes/1e6,
-                                    TMP_MIN_FREE_SPACE_BYTES/1e6))
+
+        # if (func_key_size + data_key_size) > (free_disk_bytes - TMP_MIN_FREE_SPACE_BYTES):
+        #     raise Exception("ARGS_TOO_BIG",
+        #                     "data + func too large {:3.1f} MB (data={:3.1f}MB, func={:3.1f}MB)," \
+        #                     " free space on worker is {:3.1f} MB, " \
+        #                     " need at least {:3.1f} MB of free space headroom to run"\
+        #                     .format((func_key_size + data_key_size)/1e6,
+        #                             data_key_size/1e6, func_key_size/1e6,
+        #                             free_disk_bytes/1e6,
+        #                             TMP_MIN_FREE_SPACE_BYTES/1e6))
         # get the input and save to disk
         # FIXME here is we where we would attach the "canceled" metadata
-        s3_transfer.download_file(s3_bucket, func_key, func_filename)
-        func_download_time = time.time() - start_time
-        response_status['func_download_time'] = func_download_time
+        #s3_transfer.download_file(s3_bucket, func_key, func_filename)
+        #func_download_time = time.time() - start_time
+        #response_status['func_download_time'] = func_download_time
 
-        logger.info("func download complete, took {:3.2f} sec".format(func_download_time))
+        #logger.info("func download complete, took {:3.2f} sec".format(func_download_time))
 
-        if data_byte_range is None:
-            s3_transfer.download_file(s3_bucket, data_key, data_filename)
-        else:
-            range_str = 'bytes={}-{}'.format(*data_byte_range)
-            dres = s3_client.get_object(Bucket=s3_bucket, Key=data_key,
-                                        Range=range_str)
-            data_fid = open(data_filename, 'wb')
-            data_fid.write(dres['Body'].read())
-            data_fid.close()
+        # if data_byte_range is None:
+        #     s3_transfer.download_file(s3_bucket, data_key, data_filename)
+        # else:
+        #     range_str = 'bytes={}-{}'.format(*data_byte_range)
+        #     dres = s3_client.get_object(Bucket=s3_bucket, Key=data_key,
+        #                                 Range=range_str)
+        #     data_fid = open(data_filename, 'wb')
+        #     data_fid.write(dres['Body'].read())
+        #     data_fid.close()
 
-        data_download_time = time.time() - start_time
-        logger.info("data data download complete, took {:3.2f} sec".format(data_download_time))
-        response_status['data_download_time'] = data_download_time
+        # data_download_time = time.time() - start_time
+        # logger.info("data data download complete, took {:3.2f} sec".format(data_download_time))
+        # response_status['data_download_time'] = data_download_time
 
-        # d = json.load(open(func_filename, 'r'))
         # clean up for modules
         shutil.rmtree(PYTHON_MODULE_PATH, True) # delete old modules
         os.mkdir(PYTHON_MODULE_PATH)
-
-        # # get modules and save
-        # for m_filename, m_data in d['module_data'].items():
-        #     m_path = os.path.dirname(m_filename)
-
-        #     if len(m_path) > 0 and m_path[0] == "/":
-        #         m_path = m_path[1:]
-        #     to_make = os.path.join(PYTHON_MODULE_PATH, m_path)
-        #     try:
-        #         os.makedirs(to_make)
-        #     except OSError as e:
-        #         if e.errno == 17:
-        #             pass
-        #         else:
-        #             raise e
-        #     full_filename = os.path.join(to_make, os.path.basename(m_filename))
-        #     #print "creating", full_filename
-        #     fid = open(full_filename, 'wb')
-        #     fid.write(b64str_to_bytes(m_data))
-        #     fid.close()
-        # logger.info("Finished writing {} module files".format(len(d['module_data'])))
-        # logger.debug(subprocess.check_output("find {}".format(PYTHON_MODULE_PATH), shell=True))
-        # logger.debug(subprocess.check_output("find {}".format(os.getcwd()), shell=True))
 
         response_status['runtime_s3_key_used'] = runtime_s3_key_used
         response_status['runtime_s3_bucket_used'] = runtime_s3_bucket_used

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -245,32 +245,33 @@ def generic_handler(event, context_dict):
         logger.info("data data download complete, took {:3.2f} sec".format(data_download_time))
         response_status['data_download_time'] = data_download_time
 
-        # now split
         d = json.load(open(func_filename, 'r'))
+        # clean up for modules
         shutil.rmtree(PYTHON_MODULE_PATH, True) # delete old modules
         os.mkdir(PYTHON_MODULE_PATH)
-        # get modules and save
-        for m_filename, m_data in d['module_data'].items():
-            m_path = os.path.dirname(m_filename)
 
-            if len(m_path) > 0 and m_path[0] == "/":
-                m_path = m_path[1:]
-            to_make = os.path.join(PYTHON_MODULE_PATH, m_path)
-            try:
-                os.makedirs(to_make)
-            except OSError as e:
-                if e.errno == 17:
-                    pass
-                else:
-                    raise e
-            full_filename = os.path.join(to_make, os.path.basename(m_filename))
-            #print "creating", full_filename
-            fid = open(full_filename, 'wb')
-            fid.write(b64str_to_bytes(m_data))
-            fid.close()
-        logger.info("Finished writing {} module files".format(len(d['module_data'])))
-        logger.debug(subprocess.check_output("find {}".format(PYTHON_MODULE_PATH), shell=True))
-        logger.debug(subprocess.check_output("find {}".format(os.getcwd()), shell=True))
+        # # get modules and save
+        # for m_filename, m_data in d['module_data'].items():
+        #     m_path = os.path.dirname(m_filename)
+
+        #     if len(m_path) > 0 and m_path[0] == "/":
+        #         m_path = m_path[1:]
+        #     to_make = os.path.join(PYTHON_MODULE_PATH, m_path)
+        #     try:
+        #         os.makedirs(to_make)
+        #     except OSError as e:
+        #         if e.errno == 17:
+        #             pass
+        #         else:
+        #             raise e
+        #     full_filename = os.path.join(to_make, os.path.basename(m_filename))
+        #     #print "creating", full_filename
+        #     fid = open(full_filename, 'wb')
+        #     fid.write(b64str_to_bytes(m_data))
+        #     fid.close()
+        # logger.info("Finished writing {} module files".format(len(d['module_data'])))
+        # logger.debug(subprocess.check_output("find {}".format(PYTHON_MODULE_PATH), shell=True))
+        # logger.debug(subprocess.check_output("find {}".format(os.getcwd()), shell=True))
 
         response_status['runtime_s3_key_used'] = runtime_s3_key_used
         response_status['runtime_s3_bucket_used'] = runtime_s3_bucket_used
@@ -300,16 +301,15 @@ def generic_handler(event, context_dict):
                             'func_key' : func_key, 
                             'data_bucket' : s3_bucket, 
                             'data_key' : data_key, 
-                            'data_byte_range' : data_byte_range}
+                            'data_byte_range' : data_byte_range, 
+                            'python_module_path' : PYTHON_MODULE_PATH}
         with open(jobrunner_config_filename, 'w') as jobrunner_fid:
             json.dump(jobrunner_config, jobrunner_fid)
  
-        cmdstr = "{} {} {} {} {} {}".format(CONDA_PYTHON_RUNTIME,
-                                               jobrunner_path,
-                                               func_filename,
-                                               data_filename,
-                                               output_filename, 
-                                               jobrunner_config_filename)
+        cmdstr = "{} {} {} {}".format(CONDA_PYTHON_RUNTIME,
+                                      jobrunner_path,
+                                      jobrunner_config_filename,
+                                      output_filename)
 
         setup_time = time.time()
         response_status['setup_time'] = setup_time - start_time

--- a/tests/test_dummy_invoker.py
+++ b/tests/test_dummy_invoker.py
@@ -29,26 +29,38 @@ class SimpleAsync(unittest.TestCase):
         res = fut.result() 
         self.assertEqual(res, np.sum(x))
 
-    def test_exception(self):
-        def throwexcept(x):
-            raise Exception("Throw me out!")
+    def test_simple_map(self):
 
-        wrenexec = pywren.default_executor()
-        fut = self.wrenexec.call_async(throwexcept, None)
-        self.wrenexec.invoker.run_jobs()
+        def plus_one(x):
+            return x + 1
+
+        x = np.arange(4)
+        futures = self.wrenexec.map(plus_one, x)
         
-        with pytest.raises(Exception) as execinfo:
-            res = fut.result() 
-        assert 'Throw me out!' in str(execinfo.value)
-
-
-    def test_subprocess(self):
-        def uname(x):
-            return subprocess.check_output("uname -a", shell=True)
-        
-        fut = self.wrenexec.call_async(uname, None)
         self.wrenexec.invoker.run_jobs()
+        res = pywren.get_all_results(futures)
+        np.testing.assert_array_equal(res, x + 1)
 
-        res = fut.result() 
+    # def test_exception(self):
+    #     def throwexcept(x):
+    #         raise Exception("Throw me out!")
+
+    #     wrenexec = pywren.default_executor()
+    #     fut = self.wrenexec.call_async(throwexcept, None)
+    #     self.wrenexec.invoker.run_jobs()
+        
+    #     with pytest.raises(Exception) as execinfo:
+    #         res = fut.result() 
+    #     assert 'Throw me out!' in str(execinfo.value)
+
+
+    # def test_subprocess(self):
+    #     def uname(x):
+    #         return subprocess.check_output("uname -a", shell=True)
+        
+    #     fut = self.wrenexec.call_async(uname, None)
+    #     self.wrenexec.invoker.run_jobs()
+
+    #     res = fut.result() 
 
 

--- a/tests/test_dummy_invoker.py
+++ b/tests/test_dummy_invoker.py
@@ -29,38 +29,38 @@ class SimpleAsync(unittest.TestCase):
         res = fut.result() 
         self.assertEqual(res, np.sum(x))
 
-    # def test_simple_map(self):
+    def test_simple_map(self):
 
-    #     def plus_one(x):
-    #         return x + 1
+        def plus_one(x):
+            return x + 1
 
-    #     x = np.arange(4)
-    #     futures = self.wrenexec.map(plus_one, x)
+        x = np.arange(4)
+        futures = self.wrenexec.map(plus_one, x)
         
-    #     self.wrenexec.invoker.run_jobs()
-    #     res = pywren.get_all_results(futures)
-    #     np.testing.assert_array_equal(res, x + 1)
+        self.wrenexec.invoker.run_jobs()
+        res = pywren.get_all_results(futures)
+        np.testing.assert_array_equal(res, x + 1)
 
-    # def test_exception(self):
-    #     def throwexcept(x):
-    #         raise Exception("Throw me out!")
+    def test_exception(self):
+        def throwexcept(x):
+            raise Exception("Throw me out!")
 
-    #     wrenexec = pywren.default_executor()
-    #     fut = self.wrenexec.call_async(throwexcept, None)
-    #     self.wrenexec.invoker.run_jobs()
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(throwexcept, None)
+        self.wrenexec.invoker.run_jobs()
         
-    #     with pytest.raises(Exception) as execinfo:
-    #         res = fut.result() 
-    #     assert 'Throw me out!' in str(execinfo.value)
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+        assert 'Throw me out!' in str(execinfo.value)
 
 
-    # def test_subprocess(self):
-    #     def uname(x):
-    #         return subprocess.check_output("uname -a", shell=True)
+    def test_subprocess(self):
+        def uname(x):
+            return subprocess.check_output("uname -a", shell=True)
         
-    #     fut = self.wrenexec.call_async(uname, None)
-    #     self.wrenexec.invoker.run_jobs()
+        fut = self.wrenexec.call_async(uname, None)
+        self.wrenexec.invoker.run_jobs()
 
-    #     res = fut.result() 
+        res = fut.result() 
 
 

--- a/tests/test_dummy_invoker.py
+++ b/tests/test_dummy_invoker.py
@@ -29,17 +29,17 @@ class SimpleAsync(unittest.TestCase):
         res = fut.result() 
         self.assertEqual(res, np.sum(x))
 
-    def test_simple_map(self):
+    # def test_simple_map(self):
 
-        def plus_one(x):
-            return x + 1
+    #     def plus_one(x):
+    #         return x + 1
 
-        x = np.arange(4)
-        futures = self.wrenexec.map(plus_one, x)
+    #     x = np.arange(4)
+    #     futures = self.wrenexec.map(plus_one, x)
         
-        self.wrenexec.invoker.run_jobs()
-        res = pywren.get_all_results(futures)
-        np.testing.assert_array_equal(res, x + 1)
+    #     self.wrenexec.invoker.run_jobs()
+    #     res = pywren.get_all_results(futures)
+    #     np.testing.assert_array_equal(res, x + 1)
 
     # def test_exception(self):
     #     def throwexcept(x):

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -96,12 +96,9 @@ def test_too_big_runtime():
         f.result()
 
 @lamb   
-def test_too_big_args():
+def test_big_args():
     """
-    This is a test where the data is too large
-    to fit on the temporary space on the lambdas. 
-    Again, somewhat brittle, lambda specific, and will
-    break when they change the available /tmp space limits. 
+    This is a test to see if we can upload large args
 
     Note this test takes a long time because of the large amount of
     data that must be uploaded. 
@@ -113,20 +110,18 @@ def test_too_big_args():
 
     data = "0"*(DATA_MB*1000000)
 
+    ## data argument large
     def simple_foo(x):
         return 1.0
     
-    
     f = wrenexec.call_async(simple_foo, data)
-    with pytest.raises(Exception) as excinfo:
-        f.result()
-    assert excinfo.value.args[1] == 'ARGS_TOO_BIG'
-
+    assert f.result() == 1.0
+    
+    ## func large
     def simple_foo_2(x):
         #capture data in the closure
         return len(data)
 
     f = wrenexec.call_async(simple_foo_2, None)
-    with pytest.raises(Exception) as excinfo:
-        f.result()
-    assert excinfo.value.args[1] == 'ARGS_TOO_BIG'
+    assert f.result() == len(data)
+    


### PR DESCRIPTION
Right now we save func and data to disk and THEN invoke jobrunner, with the idea of jobrunner being as simple as possible. As a result, the size of func + data + runtime < worker /tmp space. It's not unreasonable to expect data to sometimes be large. We then load func and data into memory anyway. This PR shifts reading those items from S3 into `jobrunner.py`. 

Advantages:
- Now func and data can be as large as memory! 
- Wrenhandler becomes simpler

Disadvantages:
- Slightly harder to get logging information out of jobrunner for when access fails. 
- Harder to get s3 download metrics out as well

I wanted to solicit feedback on this early.  I think this is a much better approach and IIRC @Vaishaal was explicitly asking for it. 