### PR TITLE
add download stats back in, fixes 188

### DIFF
--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -4,7 +4,9 @@ import base64
 import shutil
 import json
 import sys
+import time
 import boto3
+
 
 from six.moves import cPickle as pickle
 from tblib import pickling_support
@@ -41,9 +43,21 @@ data_byte_range = jobrunner_config['data_byte_range']
 output_bucket = jobrunner_config['output_bucket']
 output_key = jobrunner_config['output_key']
 
+## Jobrunner stats are fieldname float
+jobrunner_stats_filename = jobrunner_config['stats_filename']
+# open the stats filename
+stats_fid = open(jobrunner_stats_filename, 'w')
+
+def write_stat(stat, val):
+    stats_fid.write("{} {:f}\n".format(stat, val))
+
 try:
+    func_download_time_t1 = time.time()
     func_obj_stream = s3_client.get_object(Bucket=func_bucket, Key=func_key)
     loaded_func_all = pickle.loads(func_obj_stream['Body'].read())
+    func_download_time_t2 = time.time()
+    write_stat('func_download_time',
+               func_download_time_t2-func_download_time_t1)
 
     # save modules, before we unpickle actual function
     PYTHON_MODULE_PATH = jobrunner_config['python_module_path']
@@ -82,10 +96,15 @@ try:
     if data_byte_range is not None:
         range_str = 'bytes={}-{}'.format(*data_byte_range)
         extra_get_args['Range'] = range_str
+
+    data_download_time_t1 = time.time()
     data_obj_stream = s3_client.get_object(Bucket=data_bucket,
                                            Key=data_key, **extra_get_args)
     # FIXME make this streaming
     loaded_data = pickle.loads(data_obj_stream['Body'].read())
+    data_download_time_t2 = time.time()
+    write_stat('data_download_time',
+               data_download_time_t2-data_download_time_t1)
 
     #print("loaded")
     y = loaded_func(loaded_data)
@@ -127,6 +146,10 @@ except Exception as e:
                                        'pickle_exception' : pickle_exception,
                                        'success' : False})
 finally:
+    output_upload_timestamp_t1 = time.time()
     s3_client.put_object(Body=pickled_output,
                          Bucket=output_bucket,
                          Key=output_key)
+    output_upload_timestamp_t2 = time.time()
+    write_stat("output_upload_time",
+               output_upload_timestamp_t2 - output_upload_timestamp_t1)

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -50,6 +50,7 @@ stats_fid = open(jobrunner_stats_filename, 'w')
 
 def write_stat(stat, val):
     stats_fid.write("{} {:f}\n".format(stat, val))
+    stats_fid.flush()
 
 try:
     func_download_time_t1 = time.time()


### PR DESCRIPTION
We removed func/data download metrics in the migration to jobrunner; this restores them by adding them to the jobrunner. Jobrunner now just writes a simple text file that we can read in. It's a text file so that we can write it line-by-line and hopefully still have some stats even if the job dies. 

Fixes #188 