### PR TITLE
Fix issue 186

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pytest cython nose boto3 PyYAML Click pytest numba
   - source activate test-environment
-  - pip install glob2 pylint tornado
+  - pip install glob2 pylint tornado awscli
   - tests/install_pywren.sh
 
 

--- a/pywren/__init__.py
+++ b/pywren/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from pywren import wrenlogging
 from pywren.wren import * # pylint: disable=wildcard-import
+from pywren.version import __version__ #pylint : disable: unused-variable
 
 if "PYWREN_LOGLEVEL" in os.environ:
     log_level = os.environ['PYWREN_LOGLEVEL']

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -37,7 +37,7 @@ def lambda_executor(config=None, job_max_runtime=280):
     return Executor(invoker, config, job_max_runtime)
 
 
-def dummy_executor(config=None, job_max_runtime=100):
+def dummy_executor(config=None, job_max_runtime=300):
     if config is None:
         config = wrenconfig.default()
 

--- a/tests/ec2_standalone_tests.sh
+++ b/tests/ec2_standalone_tests.sh
@@ -4,7 +4,18 @@ set -x
 if [ "$RUN_STANDALONE" != "true" ]; then
     exit 0
 fi
+# sometimes the instance profile isn't visible yet to the function.
+# this results in erratic test behavior and tests sometimes failing
 
+n=0
+until [ $n -ge 5 ]
+do
+    aws get-instance-profile --instance-profile-name pywren_travis_$BUILD_GUID && break  # substitute your command here
+    echo "instance profile was not available, retrying"
+    n=$[$n+1]
+    sleep 10
+done
+   
 pywren standalone launch_instances 1 --max_idle_time=10 --idle_terminate_granularity=600 --pywren_git_commit=$TRAVIS_COMMIT
 sleep 20
 export PYWREN_EXECUTOR=remote

--- a/tests/ec2_standalone_tests.sh
+++ b/tests/ec2_standalone_tests.sh
@@ -10,7 +10,7 @@ fi
 n=0
 until [ $n -ge 5 ]
 do
-    aws iam get-instance-profile --instance-profile-name pywren_travis_$BUILD_GUID && break  # substitute your command here
+    aws iam get-instance-profile --instance-profile-name pywren_travis_$BUILD_GUID > /dev/null && break
     echo "instance profile was not available, retrying"
     n=$[$n+1]
     sleep 10

--- a/tests/ec2_standalone_tests.sh
+++ b/tests/ec2_standalone_tests.sh
@@ -10,7 +10,7 @@ fi
 n=0
 until [ $n -ge 5 ]
 do
-    aws get-instance-profile --instance-profile-name pywren_travis_$BUILD_GUID && break  # substitute your command here
+    aws iam get-instance-profile --instance-profile-name pywren_travis_$BUILD_GUID && break  # substitute your command here
     echo "instance profile was not available, retrying"
     n=$[$n+1]
     sleep 10

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,18 +1,24 @@
-import pytest
-import numpy as np
-import time
-import pywren.wrenutil
 import unittest
+import pytest
+import pywren
+import pywren.wrenutil
+
 
 class S3HashingTest(unittest.TestCase):
     def test_s3_split(self):
-        
+
         good_s3_url = "s3://bucket_name/and/the/key"
         bucket, key = pywren.wrenutil.split_s3_url(good_s3_url)
-        
+
         self.assertEqual(bucket, "bucket_name")
         self.assertEqual(key, "and/the/key")
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             bad_s3_url = "notS3://foo/bar"
             bucket, key = pywren.wrenutil.split_s3_url(bad_s3_url)
+
+def test_version():
+    """
+    test that __version__ exists
+    """
+    assert pywren.__version__ is not None


### PR DESCRIPTION
Fixes issue #186 restoring `__version__` but also fixes some test case bugs:
1. IAM instance-profile information takes a bit to propagate so standalone tests sometimes fail
2. the dummy-invoker tests sometimes is a bit slow due to downloading runtime ; we extended its max runtime to compensate. 