### PR TITLE
Add ability to cancel a job [WIP]

### DIFF
--- a/pywren/executor.py
+++ b/pywren/executor.py
@@ -59,7 +59,7 @@ class Executor(object):
                                                                       data_key))
 
     def invoke_with_keys(self, func_key, data_key, output_key,
-                         status_key,
+                         status_key, cancel_key, 
                          callset_id, call_id, extra_env,
                          extra_meta, data_byte_range, use_cached_runtime,
                          host_job_meta, job_max_runtime,
@@ -82,6 +82,7 @@ class Executor(object):
             'data_key' : data_key,
             'output_key' : output_key,
             'status_key' : status_key,
+            'cancel_key' : cancel_key, 
             'callset_id': callset_id,
             'job_max_runtime' : job_max_runtime,
             'data_byte_range' : data_byte_range,
@@ -219,8 +220,9 @@ class Executor(object):
         def invoke(data_str, callset_id, call_id, func_key,
                    host_job_meta,
                    agg_data_key=None, data_byte_range=None):
-            data_key, output_key, status_key \
-                = storage_utils.create_keys(self.storage.prefix, callset_id, call_id)
+            keys = storage_utils.create_keys(self.storage.prefix, 
+                                             callset_id, call_id)
+            data_key, output_key, status_key, cancel_key = keys
 
             host_job_meta['job_invoke_timestamp'] = time.time()
 
@@ -239,6 +241,7 @@ class Executor(object):
             return self.invoke_with_keys(func_key, data_key,
                                          output_key,
                                          status_key,
+                                         cancel_key,
                                          callset_id, call_id, extra_env,
                                          extra_meta, data_byte_range,
                                          use_cached_runtime, host_job_meta.copy(),

--- a/pywren/executor.py
+++ b/pywren/executor.py
@@ -59,7 +59,7 @@ class Executor(object):
                                                                       data_key))
 
     def invoke_with_keys(self, func_key, data_key, output_key,
-                         status_key, cancel_key, 
+                         status_key, cancel_key,
                          callset_id, call_id, extra_env,
                          extra_meta, data_byte_range, use_cached_runtime,
                          host_job_meta, job_max_runtime,
@@ -82,7 +82,7 @@ class Executor(object):
             'data_key' : data_key,
             'output_key' : output_key,
             'status_key' : status_key,
-            'cancel_key' : cancel_key, 
+            'cancel_key' : cancel_key,
             'callset_id': callset_id,
             'job_max_runtime' : job_max_runtime,
             'data_byte_range' : data_byte_range,
@@ -220,7 +220,7 @@ class Executor(object):
         def invoke(data_str, callset_id, call_id, func_key,
                    host_job_meta,
                    agg_data_key=None, data_byte_range=None):
-            keys = storage_utils.create_keys(self.storage.prefix, 
+            keys = storage_utils.create_keys(self.storage.prefix,
                                              callset_id, call_id)
             data_key, output_key, status_key, cancel_key = keys
 

--- a/pywren/future.py
+++ b/pywren/future.py
@@ -58,6 +58,13 @@ class ResponseFuture(object):
         self._state = new_state
 
     def cancel(self):
+        storage_config = wrenconfig.extract_storage_config(wrenconfig.default())
+        storage_handler = storage.Storage(storage_config)
+
+        call_status = storage_handler.get_call_status(self.callset_id, 
+                                                      self.call_id)
+
+
         raise NotImplementedError("Cannot cancel dispatched jobs")
 
     def cancelled(self):

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -6,6 +6,7 @@ import os
 import botocore
 import botocore.session
 from pywren import local
+import threading
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -47,7 +48,8 @@ class DummyInvoker(object):
     does not delete left-behind jobs
 
     """
-
+    
+    DEFAULT_RUN_DIR = "/tmp/task"
     def __init__(self):
         self.payloads = []
         self.TIME_LIMIT = False
@@ -59,7 +61,7 @@ class DummyInvoker(object):
         return {}
 
 
-    def run_jobs(self, MAXJOBS=-1, run_dir="/tmp/task"):
+    def run_jobs(self, MAXJOBS=-1, run_dir=DEFAULT_RUN_DIR):
         """
         run MAXJOBS in the queue
         MAXJOBS = -1  to run all
@@ -76,3 +78,14 @@ class DummyInvoker(object):
                             {'invoker' : 'DummyInvoker'})
 
         self.payloads = self.payloads[jobn:]
+
+    def run_jobs_threaded(self, MAXJOBS=-1, 
+                           run_dir=DEFAULT_RUN_DIR):
+        """
+        Just like run_jobs but in a separate thread
+        (so it's non-blocking)
+        """
+        
+        self.thread = threading.Thread(target=self.run_jobs, 
+                                       args=(MAXJOBS, run_dir))
+        self.thread.start()

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import
 
 import json
 import os
+import threading
 
 import botocore
 import botocore.session
 from pywren import local
-import threading
+
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -48,11 +49,12 @@ class DummyInvoker(object):
     does not delete left-behind jobs
 
     """
-    
+
     DEFAULT_RUN_DIR = "/tmp/task"
     def __init__(self):
         self.payloads = []
         self.TIME_LIMIT = False
+        self.thread = None
 
     def invoke(self, payload):
         self.payloads.append(payload)
@@ -79,13 +81,12 @@ class DummyInvoker(object):
 
         self.payloads = self.payloads[jobn:]
 
-    def run_jobs_threaded(self, MAXJOBS=-1, 
-                           run_dir=DEFAULT_RUN_DIR):
+    def run_jobs_threaded(self, MAXJOBS=-1, run_dir=DEFAULT_RUN_DIR):
         """
         Just like run_jobs but in a separate thread
         (so it's non-blocking)
         """
-        
-        self.thread = threading.Thread(target=self.run_jobs, 
+
+        self.thread = threading.Thread(target=self.run_jobs,
                                        args=(MAXJOBS, run_dir))
         self.thread.start()

--- a/pywren/storage/storage.py
+++ b/pywren/storage/storage.py
@@ -5,7 +5,8 @@ import os
 
 from  .exceptions import StorageNoSuchKeyError, StorageOutputNotFoundError
 from .s3_backend import S3Backend
-from .storage_utils import create_status_key, create_output_key, status_key_suffix, create_cancel_key
+from .storage_utils import create_status_key, create_output_key
+from .storage_utils import status_key_suffix, create_cancel_key
 
 
 class Storage(object):

--- a/pywren/storage/storage.py
+++ b/pywren/storage/storage.py
@@ -5,7 +5,7 @@ import os
 
 from  .exceptions import StorageNoSuchKeyError, StorageOutputNotFoundError
 from .s3_backend import S3Backend
-from .storage_utils import create_status_key, create_output_key, status_key_suffix
+from .storage_utils import create_status_key, create_output_key, status_key_suffix, create_cancel_key
 
 
 class Storage(object):
@@ -50,6 +50,17 @@ class Storage(object):
         :return: None
         """
         return self.backend_handler.put_object(key, func)
+
+    def put_canceled(self, callset_id, call_id, canceled_data):
+        """
+        Put data to signal cancel into storage
+        :param key: cancel_key
+        :param func: canceled_data
+        :return: None
+        """
+        key = create_cancel_key(self.prefix, callset_id,
+                                call_id)
+        return self.backend_handler.put_object(key, canceled_data)
 
     def get_callset_status(self, callset_id):
         """

--- a/pywren/storage/storage_utils.py
+++ b/pywren/storage/storage_utils.py
@@ -86,7 +86,7 @@ def create_keys(prefix, callset_id, call_id):
     output_key = create_output_key(prefix, callset_id, call_id)
     status_key = create_status_key(prefix, callset_id, call_id)
     cancel_key = create_cancel_key(prefix, callset_id, call_id)
-    return data_key, output_key, status_key
+    return data_key, output_key, status_key, cancel_key
 
 
 def get_storage_path(config):

--- a/pywren/storage/storage_utils.py
+++ b/pywren/storage/storage_utils.py
@@ -7,6 +7,7 @@ agg_data_key_suffix = "aggdata.pickle"
 data_key_suffix = "data.pickle"
 output_key_suffix = "output.pickle"
 status_key_suffix = "status.json"
+cancel_key_suffix = "cancel"
 
 def create_func_key(prefix, callset_id):
     """
@@ -62,6 +63,16 @@ def create_status_key(prefix, callset_id, call_id):
     """
     return os.path.join(prefix, callset_id, call_id, status_key_suffix)
 
+def create_cancel_key(prefix, callset_id, call_id):
+    """
+    Create cancel key
+    :param prefix: prefix
+    :param callset_id: callset's ID
+    :param call_id: call's ID
+    :return: status key
+    """
+    return os.path.join(prefix, callset_id, call_id, cancel_key_suffix)
+
 
 def create_keys(prefix, callset_id, call_id):
     """
@@ -69,11 +80,12 @@ def create_keys(prefix, callset_id, call_id):
     :param prefix: prefix
     :param callset_id: callset's ID
     :param call_id: call's ID
-    :return: data_key, output_key, status_key
+    :return: data_key, output_key, status_key, cancel_key
     """
     data_key = create_data_key(prefix, callset_id, call_id)
     output_key = create_output_key(prefix, callset_id, call_id)
     status_key = create_status_key(prefix, callset_id, call_id)
+    cancel_key = create_cancel_key(prefix, callset_id, call_id)
     return data_key, output_key, status_key
 
 

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -306,21 +306,20 @@ def generic_handler(event, context_dict):
                 time.sleep(PROCESS_STDOUT_SLEEP_SECS)
             total_runtime = time.time() - start_time
             time_since_cancel_check = time.time() - time_of_last_cancel_check
-            print("here:", s3_bucket, cancel_key, 
-                  get_key_size(s3_client, s3_bucket, cancel_key), 
+            print("here:", s3_bucket, cancel_key,
+                  get_key_size(s3_client, s3_bucket, cancel_key),
                   time_since_cancel_check)
             if time_since_cancel_check > CANCEL_CHECK_EVERY_SECS:
-                
+
                 if key_exists(s3_client, s3_bucket, cancel_key):
                     logger.info("invocation cancelled")
                     print("CANCELING")
                     # kill the process
                     os.killpg(os.getpgid(process.pid), signal.SIGTERM)
-                    raise Exception("CANCELLED", 
+                    raise Exception("CANCELLED",
                                     "Function canceled")
-                time_since_last_cancel_check = time.time()
+                time_of_last_cancel_check = time.time()
 
-                
             if total_runtime > job_max_runtime:
                 logger.warning("Process exceeded maximum runtime of {} sec".format(job_max_runtime))
                 # Send the signal to all the process groups

--- a/tests/test_dummy_invoker.py
+++ b/tests/test_dummy_invoker.py
@@ -64,3 +64,18 @@ class SimpleAsync(unittest.TestCase):
         res = fut.result() 
 
 
+    def test_cancel(self):
+
+        def sleep(x):
+            time.sleep(x)
+            return 0
+
+        fut = self.wrenexec.call_async(sleep, 30)
+
+        self.wrenexec.invoker.run_jobs_threaded()
+        time.sleep(4)
+        fut.cancel()
+        with pytest.raises(Exception) as execinfo:
+            _ = fut.result()
+
+        assert "canceled" in str(execinfo.value)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -87,6 +87,20 @@ class SimpleAsync(unittest.TestCase):
         assert exc_type_wren == exc_type_true
         assert type(exc_value_wren) == type(exc_value_true)
 
+    def test_cancel(self):
+
+        def sleep(x):
+            time.sleep(x)
+            return 0
+
+        fut = self.wrenexec.call_async(sleep, 30)
+        time.sleep(2)
+        fut.cancel()
+
+        with pytest.raises(Exception) as execinfo:
+            _ = fut.result()
+
+        assert "canceled" in str(execinfo.value)
 
 class SimpleMap(unittest.TestCase):
 


### PR DESCRIPTION
# What 
This adds the ability to cancel a job, by making `.cancel()` method of a future actually do something.

# Why
- If you launch 1e4 lambdas and then think "oops!" this lets you bleed through the queue quickly -- the lambdas will each run for like 100ms to clear out the queue. 
- if you are using standalone mode for long-running tasks like deepnets and want to abort the remote work, this is the only supported way of saying "oops" and actually cancelling the deepnet process while it is running. 

# How 
 All it does is write a `cancel` key to s3; which our runner periodically polls for. We check for the cancel job id

1. at the very beginning of the job
2. every `CANCEL_CHECK_EVERY_SECS` while running the actual function 

and then return an exception for the canceled functions. 


Note that a function's "canceled" status isn't set on the client side but rather the client side writes the key and then relies on the remote to signal (via the exception) that it was canceled. Sometimes functions may be canceled but it's noticed remotely too late, or they are already done. 

*Looking for feedback here. *

This once again exposed some of the weaknesses in our storage configuration abstraction; once again the future has to create a default storage handler inside itself. 

associated with issue #187 