### PR TITLE
Make runtime s3_bucket to hard-coded value

### DIFF
--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -99,7 +99,8 @@ def create_config(ctx, force, aws_region, lambda_role, function_name, bucket_nam
         print('Python 2.7 runtime will be used for remote.')
         pythonver = '2.7'
 
-    runtime_bucket = 'pywren-public-{}'.format(aws_region)
+    # FIXME does pywren-public-other-regions exists?
+    runtime_bucket = 'pywren-public-us-west-2'
     default_yaml = default_yaml.replace("RUNTIME_BUCKET",
                                         runtime_bucket)
     k = pywren.wrenconfig.default_runtime[pythonver]


### PR DESCRIPTION
Temporary solution for #220 issue.

Hard-code runtime s3 region to `us-west-2`.

This make #220 fixed for now.