### PR TITLE
Portability

### DIFF
--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -5,7 +5,7 @@ import shutil
 import json
 import sys
 import time
-import boto3
+from storage.storage import Storage
 
 
 from six.moves import cPickle as pickle
@@ -28,10 +28,9 @@ jobrunner_config_filename = sys.argv[1]
 
 jobrunner_config = json.load(open(jobrunner_config_filename, 'r'))
 
-
 # FIXME someday switch to storage handler
 # download the func data into memory
-s3_client = boto3.client("s3")
+storage_handler = Storage(jobrunner_config['storage_config'])
 
 func_bucket = jobrunner_config['func_bucket']
 func_key = jobrunner_config['func_key']
@@ -54,8 +53,8 @@ def write_stat(stat, val):
 
 try:
     func_download_time_t1 = time.time()
-    func_obj_stream = s3_client.get_object(Bucket=func_bucket, Key=func_key)
-    loaded_func_all = pickle.loads(func_obj_stream['Body'].read())
+    func_obj = storage_handler.get_object(func_key)
+    loaded_func_all = pickle.loads(func_obj)
     func_download_time_t2 = time.time()
     write_stat('func_download_time',
                func_download_time_t2-func_download_time_t1)
@@ -69,10 +68,17 @@ try:
 
     for m_filename, m_data in loaded_func_all['module_data'].items():
         m_path = os.path.dirname(m_filename)
+        if sys.platform == 'win32':
+            if len(m_path) > 0 and m_path[0] == "\\":
+                m_path = m_path[1:]
+            # fix windows forward slash delimeter
+            m_path = os.path.join(*filter(lambda x: len(x) > 0, m_path.split("/")))
 
-        if len(m_path) > 0 and m_path[0] == "/":
-            m_path = m_path[1:]
+        else:
+            if len(m_path) > 0 and m_path[0] == "/":
+                m_path = m_path[1:]
         to_make = os.path.join(PYTHON_MODULE_PATH, m_path)
+
         try:
             os.makedirs(to_make)
         except OSError as e:
@@ -93,16 +99,10 @@ try:
     # now unpickle function; it will expect modules to be there
     loaded_func = pickle.loads(loaded_func_all['func'])
 
-    extra_get_args = {}
-    if data_byte_range is not None:
-        range_str = 'bytes={}-{}'.format(*data_byte_range)
-        extra_get_args['Range'] = range_str
-
     data_download_time_t1 = time.time()
-    data_obj_stream = s3_client.get_object(Bucket=data_bucket,
-                                           Key=data_key, **extra_get_args)
+    data_obj = storage_handler.get_object(data_key, data_byte_range)
     # FIXME make this streaming
-    loaded_data = pickle.loads(data_obj_stream['Body'].read())
+    loaded_data = pickle.loads(data_obj)
     data_download_time_t2 = time.time()
     write_stat('data_download_time',
                data_download_time_t2-data_download_time_t1)
@@ -148,9 +148,7 @@ except Exception as e:
                                        'success' : False})
 finally:
     output_upload_timestamp_t1 = time.time()
-    s3_client.put_object(Body=pickled_output,
-                         Bucket=output_bucket,
-                         Key=output_key)
+    storage_handler.put_data(output_key, pickled_output)
     output_upload_timestamp_t2 = time.time()
     write_stat("output_upload_time",
                output_upload_timestamp_t2 - output_upload_timestamp_t1)

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -215,13 +215,15 @@ def deploy_lambda(ctx, update_if_exists=True):
     module_dir = os.path.join(SOURCE_DIR, "../")
 
     for f in ['wrenutil.py', 'wrenconfig.py', 'wrenhandler.py',
-              'version.py', 'jobrunner.py', 'wren.py']:
+              'version.py', 'jobrunner.py', 'wren.py', 'storage/storage.py',
+              'storage/s3_backend.py', 'storage/storage_utils.py', 'storage/exceptions.py']:
         f = os.path.abspath(os.path.join(module_dir, f))
         a = os.path.relpath(f, SOURCE_DIR + "/..")
 
         zipfile_obj.write(f, arcname=a)
+    a = os.path.relpath("storage/__init__.py", SOURCE_DIR + "/..")
+    zipfile_obj.writestr(a, "")
     zipfile_obj.close()
-    #open("/tmp/deploy.zip", 'w').write(file_like_object.getvalue())
 
     lambclient = boto3.client('lambda', region_name=AWS_REGION)
 

--- a/pywren/storage/storage.py
+++ b/pywren/storage/storage.py
@@ -25,6 +25,19 @@ class Storage(object):
         else:
             raise NotImplementedError(("Using {} as storage backend is" +
                                        "not supported yet").format(config['storage_backend']))
+    def head_object(self, key):
+        """
+        Retrieves metadata for given key.
+        The metadata dict must have Contentlength and Etag as keys
+        :return: dict
+        """
+        return self.backend_handler.head_object(key)
+
+    def get_object(self, key, data_byte_range=None):
+        """
+        Retrieves object for given key.
+        """
+        return self.backend_handler.get_object(key, data_byte_range)
 
     def get_storage_config(self):
         """

--- a/pywren/wrenconfig.py
+++ b/pywren/wrenconfig.py
@@ -38,7 +38,9 @@ def load(config_filename):
                 config_filename, res['s3']['bucket']))
     if 'storage_backend' not in res:
         res = patch_storage_config(res)
-
+    elif res['storage_backend'] == 's3':
+        res['storage_prefix'] = res['s3']['pywren_prefix']
+        res['runtime']['runtime_storage'] = 's3'
     return res
 
 def get_default_home_filename():

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -9,60 +9,79 @@ import sys
 import tarfile
 import time
 import traceback
+import platform
+
 from threading import Thread
 import io
-
-import boto3
-import botocore
 
 if sys.version_info > (3, 0):
     from queue import Queue, Empty # pylint: disable=import-error
     from . import wrenutil # pylint: disable=relative-import
     from . import version  # pylint: disable=relative-import
+    from .storage.storage import Storage
 
 else:
     from Queue import Queue, Empty # pylint: disable=import-error
     import wrenutil # pylint: disable=relative-import
     import version  # pylint: disable=relative-import
+    from storage.storage import Storage
 
-PYTHON_MODULE_PATH = "/tmp/pymodules"
-CONDA_RUNTIME_DIR = "/tmp/condaruntime"
-RUNTIME_LOC = "/tmp/runtimes"
-JOBRUNNER_CONFIG_FILENAME = "/tmp/jobrunner.config.json"
-JOBRUNNER_STATS_FILENAME = "/tmp/jobrunner.stats.txt"
+if sys.platform == 'win32':
+    TEMP = r"D:\local\Temp"
+    PATH_DELIMETER = ";"
+    import ctypes
+
+else:
+    TEMP = "/tmp"
+    PATH_DELIMETER = ":"
+
+PYTHON_MODULE_PATH = os.path.join(TEMP, "pymodules")
+CONDA_RUNTIME_DIR = os.path.join(TEMP, "condaruntime")
+RUNTIME_LOC = os.path.join(TEMP, "runtimes")
+JOBRUNNER_CONFIG_FILENAME = os.path.join(TEMP, "jobrunner.config.json")
+JOBRUNNER_STATS_FILENAME = os.path.join(TEMP, "jobrunner.stats.txt")
 
 logger = logging.getLogger(__name__)
 
 PROCESS_STDOUT_SLEEP_SECS = 2
 
-def get_key_size(s3client, bucket, key):
-    try:
-        a = s3client.head_object(Bucket=bucket, Key=key)
-        return a['ContentLength']
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == "404":
-            return None
-        else:
-            raise e
 
 def free_disk_space(dirname):
     """
     Returns the number of free bytes on the mount point containing DIRNAME
     """
-    s = os.statvfs(dirname)
-    return s.f_bsize * s.f_bavail
+    if sys.platform == 'win32':
+        free_bytes = ctypes.c_ulonglong(0)
+        ctypes.windll.kernel32.GetDiskFreeSpaceExW(ctypes.c_wchar_p(dirname),
+                                                   None, None, ctypes.pointer(free_bytes))
+        return free_bytes.value / 1024 / 1024
+    else:
+        s = os.statvfs(dirname)
+        return s.f_bsize * s.f_bavail
 
-def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
+def download_runtime_if_necessary(runtime_bucket, runtime_key):
     """
     Download the runtime if necessary
-
     return True if cached, False if not (download occured)
-
     """
+    if sys.platform == 'win32':
+        return True
+
+    # Set up storage handler for runtime.
+    backend_config = {
+        'bucket': runtime_bucket
+    }
+
+    storage_config = {
+        'storage_prefix' : None,
+        'storage_backend' : 's3',
+        'backend_config': backend_config
+    }
+    storage_handler = Storage(storage_config)
 
     # get runtime etag
-    runtime_meta = s3_client.head_object(Bucket=runtime_s3_bucket,
-                                         Key=runtime_s3_key)
+    runtime_meta = storage_handler.head_object(runtime_key)
+
     # etags have strings (double quotes) on each end, so we strip those
     ETag = str(runtime_meta['ETag'])[1:-1]
     logger.debug("The etag is ={}".format(ETag))
@@ -91,9 +110,7 @@ def download_runtime_if_necessary(s3_client, runtime_s3_bucket, runtime_s3_key):
 
     os.makedirs(runtime_etag_dir)
 
-    res = s3_client.get_object(Bucket=runtime_s3_bucket,
-                               Key=runtime_s3_key)
-    res_buffer = res['Body'].read()
+    res_buffer = storage_handler.get_object(runtime_key)
     try:
         res_buffer_io = io.BytesIO(res_buffer)
         condatar = tarfile.open(mode="r:gz", fileobj=res_buffer_io)
@@ -139,17 +156,17 @@ def aws_lambda_handler(event, context):
     # MKL does not currently play nicely with
     # containers in determining correct # of processors
     custom_handler_env = {'OMP_NUM_THREADS' : '1'}
+
     return generic_handler(event, context_dict, custom_handler_env)
 
 def get_server_info():
 
-    server_info = {'uname' : subprocess.check_output("uname -a", shell=True).decode("ascii")}
+    server_info = {'uname' : " ".join(platform.uname()),
+                   'cpuinfo': platform.processor()}
     if os.path.exists("/proc"):
-        server_info.update({'/proc/cpuinfo': open("/proc/cpuinfo", 'r').read(),
-                            '/proc/meminfo': open("/proc/meminfo", 'r').read(),
+        server_info.update({'/proc/meminfo': open("/proc/meminfo", 'r').read(),
                             '/proc/self/cgroup': open("/proc/meminfo", 'r').read(),
                             '/proc/cgroups': open("/proc/cgroups", 'r').read()})
-
 
     return server_info
 
@@ -160,6 +177,8 @@ def generic_handler(event, context_dict, custom_handler_env=None):
     context_dict is generic infromation about the context
     that we are running in, provided by the scheduler
 
+    storage_handler is the storage object that we use for IO
+
     custom_handler_env are environment variables we should set
     based on the platform we are on.
     """
@@ -169,9 +188,19 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         if event['storage_config']['storage_backend'] != 's3':
             raise NotImplementedError(("Using {} as storage backend is not supported " +
                                        "yet.").format(event['storage_config']['storage_backend']))
-        s3_client = boto3.client("s3")
-        s3_bucket = event['storage_config']['backend_config']['bucket']
 
+        # construct storage handler
+        backend_config = {
+            'bucket': event['storage_config']['backend_config']['bucket']
+        }
+
+        storage_config = {
+            'storage_prefix' : event['storage_config']['storage_prefix'],
+            'storage_backend' : event['storage_config']['storage_backend']
+            'backend_config': backend_config
+        }
+
+        storage_handler = Storage(storage_config)
         logger.info("invocation started")
 
         # download the input
@@ -188,15 +217,13 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         start_time = time.time()
         response_status['start_time'] = start_time
 
-        runtime_s3_bucket = event['runtime']['s3_bucket']
-        runtime_s3_key = event['runtime']['s3_key']
         if event.get('runtime_url'):
             # NOTE(shivaram): Right now we only support S3 urls.
-            runtime_s3_bucket_used, runtime_s3_key_used = wrenutil.split_s3_url(
+            runtime_bucket, runtime_key = wrenutil.split_s3_url(
                 event['runtime_url'])
         else:
-            runtime_s3_bucket_used = runtime_s3_bucket
-            runtime_s3_key_used = runtime_s3_key
+            runtime_bucket = event['runtime']['s3_bucket']
+            runtime_key = event['runtime']['s3_key']
 
         job_max_runtime = event.get("job_max_runtime", 290) # default for lambda
 
@@ -205,24 +232,23 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         response_status['output_key'] = output_key
         response_status['status_key'] = status_key
 
-        data_key_size = get_key_size(s3_client, s3_bucket, data_key)
+        data_key_size = storage_handler.head_object(data_key)['ContentLength']
         #logger.info("bucket=", s3_bucket, "key=", data_key,  "status: ", data_key_size, "bytes" )
         while data_key_size is None:
             logger.warning("WARNING COULD NOT GET FIRST KEY")
 
-            data_key_size = get_key_size(s3_client, s3_bucket, data_key)
+            data_key_size = storage_handler.head_object(data_key)['ContentLength']
         if not event['use_cached_runtime']:
-            subprocess.check_output("rm -Rf {}/*".format(RUNTIME_LOC), shell=True)
+            shutil.rmtree(RUNTIME_LOC, True)
+            os.mkdir(RUNTIME_LOC)
 
-
-        free_disk_bytes = free_disk_space("/tmp")
+        free_disk_bytes = free_disk_space(TEMP)
         response_status['free_disk_bytes'] = free_disk_bytes
+        response_status['runtime_s3_key_used'] = runtime_key
+        response_status['runtime_s3_bucket_used'] = runtime_bucket
 
-        response_status['runtime_s3_key_used'] = runtime_s3_key_used
-        response_status['runtime_s3_bucket_used'] = runtime_s3_bucket_used
-
-        runtime_cached = download_runtime_if_necessary(s3_client, runtime_s3_bucket_used,
-                                                       runtime_s3_key_used)
+        runtime_cached = download_runtime_if_necessary(runtime_bucket,
+                                                       runtime_key)
         logger.info("Runtime ready, cached={}".format(runtime_cached))
         response_status['runtime_cached'] = runtime_cached
 
@@ -237,20 +263,24 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         response_status['call_id'] = call_id
         response_status['callset_id'] = callset_id
 
-        CONDA_PYTHON_PATH = "/tmp/condaruntime/bin"
+        if sys.platform == 'win32':
+            CONDA_PYTHON_PATH = r"D:\home\site\wwwroot\conda\Miniconda2"
+        else:
+            CONDA_PYTHON_PATH = os.path.join(CONDA_RUNTIME_DIR, "bin")
         CONDA_PYTHON_RUNTIME = os.path.join(CONDA_PYTHON_PATH, "python")
 
         # pass a full json blob
 
-        jobrunner_config = {'func_bucket' : s3_bucket,
+        jobrunner_config = {'func_bucket' : backend_config['bucket'],
                             'func_key' : func_key,
-                            'data_bucket' : s3_bucket,
+                            'data_bucket' : backend_config['bucket'],
                             'data_key' : data_key,
                             'data_byte_range' : data_byte_range,
                             'python_module_path' : PYTHON_MODULE_PATH,
-                            'output_bucket' : s3_bucket,
+                            'output_bucket' : backend_config['bucket'],
                             'output_key' : output_key,
-                            'stats_filename' : JOBRUNNER_STATS_FILENAME}
+                            'stats_filename' : JOBRUNNER_STATS_FILENAME,
+                            'storage_config': storage_handler.storage_config}
 
         with open(JOBRUNNER_CONFIG_FILENAME, 'w') as jobrunner_fid:
             json.dump(jobrunner_config, jobrunner_fid)
@@ -271,13 +301,21 @@ def generic_handler(event, context_dict, custom_handler_env=None):
 
         local_env.update(extra_env)
 
-        local_env['PATH'] = "{}:{}".format(CONDA_PYTHON_PATH, local_env.get("PATH", ""))
+        local_env['PATH'] = "{}{}{}".format(CONDA_PYTHON_PATH, PATH_DELIMETER,
+                                            local_env.get("PATH", ""))
 
         logger.debug("command str=%s", cmdstr)
+
+        # os.setsid doesn't work in windows
+        if sys.platform == 'win32':
+            preexec = None
+        else:
+            preexec = os.setsid
+
         # This is copied from http://stackoverflow.com/a/17698359/4577954
         # reasons for setting process group: http://stackoverflow.com/a/4791612
         process = subprocess.Popen(cmdstr, shell=True, env=local_env, bufsize=1,
-                                   stdout=subprocess.PIPE, preexec_fn=os.setsid)
+                                   stdout=subprocess.PIPE, preexec_fn=preexec)
 
         logger.info("launched process")
         def consume_stdout(stdout, queue):
@@ -303,7 +341,10 @@ def generic_handler(event, context_dict, custom_handler_env=None):
             if total_runtime > job_max_runtime:
                 logger.warning("Process exceeded maximum runtime of {} sec".format(job_max_runtime))
                 # Send the signal to all the process groups
-                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                if sys.platform.startswith('linux'):
+                    os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                else:
+                    pass
                 raise Exception("OUTATIME",
                                 "Process executed for too long and was killed")
 
@@ -321,7 +362,6 @@ def generic_handler(event, context_dict, custom_handler_env=None):
 
         response_status['stdout'] = stdout.decode("ascii")
 
-
         response_status['exec_time'] = time.time() - setup_time
         response_status['end_time'] = end_time
 
@@ -336,5 +376,4 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         response_status['exception_traceback'] = traceback.format_exc()
     finally:
         # creating new client in case the client has not been created
-        boto3.client("s3").put_object(Bucket=s3_bucket, Key=status_key,
-                                      Body=json.dumps(response_status))
+        storage_handler.put_data(status_key, json.dumps(response_status))


### PR DESCRIPTION
This is to fix #154. The main changes here are

- Abstracting s3 IO to a storage handler.
- Removing any syscalls unavailable on windows.
- Making file paths portable across platforms.

This is an update of a previous PR (#155) which had these fixes, but there have been a lot of changes to the way pywren is structured, which made rebasing infeasible. This is essentially the same PR as earlier, except it follows the restructuring of `wrenhandler` and `jobrunner`.