### PR TITLE
Add synchronous invocation

### DIFF
--- a/pywren/executor.py
+++ b/pywren/executor.py
@@ -20,7 +20,7 @@ from pywren.serialize import serialize, create_mod_data
 from pywren.storage import storage_utils
 from pywren.storage.storage_utils import create_func_key
 from pywren.wait import wait, ALL_COMPLETED
-
+from pywren.invokers import LambdaSyncInvoker
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class Executor(object):
             arg_dict.update(overwrite_invoke_args)
 
         # do the invocation
-        self.invoker.invoke(arg_dict)
+        conn = self.invoker.invoke(arg_dict)
 
         host_job_meta['lambda_invoke_timestamp'] = lambda_invoke_time_start
         host_job_meta['lambda_invoke_time'] = time.time() - lambda_invoke_time_start
@@ -130,6 +130,9 @@ class Executor(object):
         fut = ResponseFuture(call_id, callset_id, host_job_meta, storage_path)
 
         fut._set_state(JobState.invoked)
+
+        if isinstance(self.invoker, LambdaSyncInvoker):
+            fut._set_conn(conn)
 
         return fut
 

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 
 import json
 import os
+import socket
+import ssl
 
 import botocore
 import botocore.session
 from pywren import local
+from pywren.wrenutil import create_request_string
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -30,6 +33,37 @@ class LambdaInvoker(object):
                                InvocationType='Event')
         # FIXME check response
         return {}
+
+    def config(self):
+        """
+        Return config dict
+        """
+        return {'lambda_function_name' : self.lambda_function_name,
+                'region_name' : self.region_name}
+
+
+class LambdaSyncInvoker(object):
+    def __init__(self, region_name, lambda_function_name):
+        self.region_name = region_name
+        self.lambda_function_name = lambda_function_name
+        self.host = 'lambda.us-west-2.amazonaws.com'.replace('us-west-2', self.region_name)
+        self.host_addr = socket.gethostbyname(self.host)
+
+    def invoke(self, payload):
+        """
+        Invoke -- return information about this invocation
+        """
+        request_str = create_request_string(self.region_name,
+                                            self.lambda_function_name,
+                                            json.dumps(payload))
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        wrapped_socket = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_SSLv23)
+        wrapped_socket.connect((self.host_addr , 443))
+        wrapped_socket.sendall(request_str)
+
+        return wrapped_socket
 
     def config(self):
         """

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -37,14 +37,19 @@ def default_executor(**kwargs):
     return lambda_executor(**kwargs)
 
 
-def lambda_executor(config=None, job_max_runtime=280):
+def lambda_executor(config=None, job_max_runtime=280, invoke_method='Event'):
     if config is None:
         config = wrenconfig.default()
 
     AWS_REGION = config['account']['aws_region']
     FUNCTION_NAME = config['lambda']['function_name']
-    invoker = invokers.LambdaInvoker(AWS_REGION, FUNCTION_NAME)
 
+    if invoke_method == 'Event':
+        invoker = invokers.LambdaInvoker(AWS_REGION, FUNCTION_NAME)
+    elif invoke_method == 'RequestResponse':
+        invoker = invokers.LambdaSyncInvoker(AWS_REGION, FUNCTION_NAME)
+    else:
+        raise NotImplementedError("Invoke method not supported.")
     return Executor(invoker, config, job_max_runtime)
 
 

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -363,3 +363,4 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         # creating new client in case the client has not been created
         boto3.client("s3").put_object(Bucket=s3_bucket, Key=status_key,
                                       Body=json.dumps(response_status))
+        return response_status

--- a/pywren/wrenutil.py
+++ b/pywren/wrenutil.py
@@ -1,8 +1,12 @@
 import base64
+import datetime
+import hashlib
+import hmac
 import os
-import uuid
-
+import requests
 import struct
+import sys
+import uuid
 
 
 def uuid_str():
@@ -124,3 +128,114 @@ def split_s3_url(s3_url):
     bucket_name = splits[0]
     key = "/".join(splits[1:])
     return bucket_name, key
+
+def create_request_string(region, function_name, request_parameters):
+
+    #
+    # https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
+    #
+    # ************* TASK 1: CREATE THE REQUEST*************
+    method = 'POST'
+    service = 'lambda'
+    host = 'lambda.us-west-2.amazonaws.com'.replace('us-west-2', region)
+    endpoint = 'https://' + host
+    path = '/2015-03-31/functions/some-function/invocations'.replace('some-function', function_name)
+    request_url = endpoint + path
+
+    # the content is JSON.
+    content_type = 'application/x-amz-json-1.0'
+
+    # Read AWS access key from env. variables or configuration file. Best practice is NOT
+    # to embed credentials in code.
+
+    access_key = os.environ.get('AWS_ACCESS_KEY_ID')
+    secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+    if access_key is None or secret_key is None:
+        print 'No access key is available.'
+        sys.exit()
+
+    # Create a date for headers and the credential string
+    t = datetime.datetime.utcnow()
+    amz_date = t.strftime('%Y%m%dT%H%M%SZ')
+    date_stamp = t.strftime('%Y%m%d') # Date w/o time, used in credential scope
+
+    canonical_uri = path
+    canonical_querystring = ''
+    canonical_headers = 'content-type:' + content_type + '\n' \
+                        + 'host:' + host + '\n' \
+                        + 'x-amz-date:' + amz_date + '\n'
+    signed_headers = 'content-type;host;x-amz-date'
+
+
+    # Create payload hash. In this example, the payload (body of
+    # the request) contains the request parameters.
+    payload_hash = hashlib.sha256(request_parameters).hexdigest()
+
+    # Combine elements to create create canonical request
+    canonical_request = method + '\n' \
+                        + canonical_uri + '\n' \
+                        + canonical_querystring + '\n' \
+                        + canonical_headers + '\n' \
+                        + signed_headers + '\n' \
+                        + payload_hash
+
+    # ************* TASK 2: CREATE THE STRING TO SIGN*************
+    # Match the algorithm to the hashing algorithm you use, either SHA-1 or
+    # SHA-256 (recommended)
+    algorithm = 'AWS4-HMAC-SHA256'
+    credential_scope = date_stamp + '/' + region + '/' + service + '/' + 'aws4_request'
+    string_to_sign = algorithm + '\n' +  amz_date + '\n' +  credential_scope + '\n' +  hashlib.sha256(canonical_request).hexdigest()
+
+
+    # ************* TASK 3: CALCULATE THE SIGNATURE *************
+    # Create the signing key using the function defined above.
+
+
+    # Key derivation functions. See:
+    # http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-python
+    def sign(key, msg):
+        return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+    def getSignatureKey(key, date_stamp, regionName, serviceName):
+        kDate = sign(('AWS4' + key).encode('utf-8'), date_stamp)
+        kRegion = sign(kDate, regionName)
+        kService = sign(kRegion, serviceName)
+        kSigning = sign(kService, 'aws4_request')
+        return kSigning
+
+
+    signing_key = getSignatureKey(secret_key, date_stamp, region, service)
+
+    # Sign the string_to_sign using the signing_key
+    signature = hmac.new(signing_key, (string_to_sign).encode('utf-8'), hashlib.sha256).hexdigest()
+
+
+    # ************* TASK 4: ADD SIGNING INFORMATION TO THE REQUEST *************
+    # Put the signature information in a header named Authorization.
+    authorization_header = algorithm + ' ' \
+                           + 'Credential=' + access_key + '/' \
+                           + credential_scope + ', ' \
+                           +  'SignedHeaders=' + signed_headers + ', ' \
+                           + 'Signature=' + signature
+
+    headers = {'authorization':authorization_header,
+               'content-type':content_type,
+               'host':host,
+               'x-amz-date':amz_date}
+
+
+    # ************* TASK 5: CONVERT REQUEST TO STRING *************
+    # Put the signature information in a header named Authorization.
+
+    req = requests.Request('POST', request_url, data=request_parameters, headers=headers)
+    prepped = req.prepare()
+
+    request_str = ""
+    request_str += method + " " + path + "?" + " " + "HTTP/1.1" + "\r\n"
+    for header in sorted(prepped.headers.keys()):
+        #print header
+        request_str += header + ":" + prepped.headers[header] + "\r\n"
+    request_str += "\r\n"
+    request_str += request_parameters
+
+    return request_str

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'Click', 'boto3', 'PyYAML',
         'enum34', 'flaky', 'glob2',
-        'watchtower', 'tblib' # it's nuts that we need both botos
+        'watchtower', 'tblib', 'requests' # it's nuts that we need both botos
     ],
     tests_requires=[
         'pytest', 'numpy',


### PR DESCRIPTION
Prototype implementation of adding synchronous invocation. The benefits of this PR are:

- Implements Lambda invocation with the `RequestResponse` method, while still maintain the non-blocking behavior of `map()`. The `RequestResponse` method gives Lambda users higher parallelism.
- Now we can use the connection that invokes Lambda to signal completion of a task. Though the old way of using a status file is maintained for compatibility.

The currents limits are:

- The connection object is kept in future. This makes the future object not serializable unless the connection object is set to None.
- We construct HTTPs requests, which needs to read AWS credentials.