### PR TITLE
add exp backoff in jobrunner get_object so it doesn't fail on start

### DIFF
--- a/pywren/jobrunner/jobrunner.py
+++ b/pywren/jobrunner/jobrunner.py
@@ -133,6 +133,7 @@ try:
 
     data_download_time_t1 = time.time()
     data_obj_stream = get_object_with_backoff(s3_client, bucket=data_bucket,
+                                              key=data_key,
                                               **extra_get_args)
     # FIXME make this streaming
     loaded_data = pickle.loads(data_obj_stream['Body'].read())

--- a/pywren/jobrunner/jobrunner.py
+++ b/pywren/jobrunner/jobrunner.py
@@ -86,7 +86,7 @@ def get_object_with_backoff(s3_client, bucket, key, max_tries=MAX_TRIES, backoff
 try:
     func_download_time_t1 = time.time()
 
-    func_obj_stream = get_object_with_backoff(s3_client, bucket=func_bucket, key=func_key, max_tries=MAX_TRIES, backoff=BACKOFF, **extra_get_args)
+    func_obj_stream = get_object_with_backoff(s3_client, bucket=func_bucket, key=func_key, **extra_get_args)
 
     loaded_func_all = pickle.loads(func_obj_stream['Body'].read())
     func_download_time_t2 = time.time()
@@ -133,7 +133,7 @@ try:
 
     data_download_time_t1 = time.time()
     data_obj_stream = get_object_with_backoff(s3_client, bucket=data_bucket,
-                                           key=data_key, max_tries=MAX_TRIES, **extra_get_args)
+                                              **extra_get_args)
     # FIXME make this streaming
     loaded_data = pickle.loads(data_obj_stream['Body'].read())
     data_download_time_t2 = time.time()

--- a/pywren/jobrunner/jobrunner.py
+++ b/pywren/jobrunner/jobrunner.py
@@ -86,7 +86,7 @@ def get_object_with_backoff(s3_client, bucket, key, max_tries=MAX_TRIES, backoff
 try:
     func_download_time_t1 = time.time()
 
-    func_obj_stream = get_object_with_backoff(s3_client, bucket=func_bucket, key=func_key, **extra_get_args)
+    func_obj_stream = get_object_with_backoff(s3_client, bucket=func_bucket, key=func_key)
 
     loaded_func_all = pickle.loads(func_obj_stream['Body'].read())
     func_download_time_t2 = time.time()

--- a/pywren/jobrunner/jobrunner.py
+++ b/pywren/jobrunner/jobrunner.py
@@ -75,7 +75,7 @@ def get_object_with_backoff(s3_client, bucket, key, max_tries=MAX_TRIES, backoff
     num_tries = 0
     while (num_tries < max_tries):
         try:
-            func_obj_stream = s3_client.get_object(Bucket=func_bucket, Key=func_key, **extra_get_args)
+            func_obj_stream = s3_client.get_object(Bucket=bucket, Key=key, **extra_get_args)
             break
         except ReadTimeoutError:
             time.sleep(backoff)
@@ -86,7 +86,7 @@ def get_object_with_backoff(s3_client, bucket, key, max_tries=MAX_TRIES, backoff
 try:
     func_download_time_t1 = time.time()
 
-    func_obj_stream = get_object_with_backoff(s3_client, bucket=func_bucket,  key=func_key)
+    func_obj_stream = get_object_with_backoff(s3_client, bucket=func_bucket, key=func_key, max_tries=MAX_TRIES, backoff=BACKOFF, **extra_get_args)
 
     loaded_func_all = pickle.loads(func_obj_stream['Body'].read())
     func_download_time_t2 = time.time()
@@ -133,7 +133,7 @@ try:
 
     data_download_time_t1 = time.time()
     data_obj_stream = get_object_with_backoff(s3_client, bucket=data_bucket,
-                                           key=data_key, **extra_get_args)
+                                           key=data_key, max_tries=MAX_TRIES, **extra_get_args)
     # FIXME make this streaming
     loaded_data = pickle.loads(data_obj_stream['Body'].read())
     data_download_time_t2 = time.time()

--- a/pywren/jobrunner/jobrunner.py
+++ b/pywren/jobrunner/jobrunner.py
@@ -132,7 +132,7 @@ try:
         extra_get_args['Range'] = range_str
 
     data_download_time_t1 = time.time()
-    data_obj_stream = get_object_with_backoff(bucket=data_bucket,
+    data_obj_stream = get_object_with_backoff(s3_client, bucket=data_bucket,
                                            key=data_key, **extra_get_args)
     # FIXME make this streaming
     loaded_data = pickle.loads(data_obj_stream['Body'].read())

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -72,7 +72,6 @@ class SimpleAsync(unittest.TestCase):
         with pytest.raises(Exception) as execinfo:
             res = fut.result() 
 
-        print("EXEC INFO ", str(execinfo.value))
         assert 'Throw me out!' in str(execinfo.value)
 
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -71,6 +71,8 @@ class SimpleAsync(unittest.TestCase):
 
         with pytest.raises(Exception) as execinfo:
             res = fut.result() 
+
+        print("EXEC INFO ", str(execinfo.value))
         assert 'Throw me out!' in str(execinfo.value)
 
 
@@ -252,7 +254,6 @@ class ConfigErrors(unittest.TestCase):
                 config = pywren.wrenconfig.default()
                 config['runtime']['s3_key'] = pywren.wrenconfig.default_runtime[wrong_version]
                 
-                    
                 with pytest.raises(Exception) as excinfo:
                     pywren.lambda_executor(config)
                 assert 'python version' in str(excinfo.value)


### PR DESCRIPTION
The travis tests for #268  were non deterministic due to S3 read of function object failing due to a timeout in job runner. So I added a few lines of exponential backoff in jobrunner so this issue wouldn't happen.