### PR TITLE
fix wait on multiple callset_ids

### DIFF
--- a/pywren/wait.py
+++ b/pywren/wait.py
@@ -130,22 +130,22 @@ def _wait(fs, return_early_n, max_direct_query_n,
     ### Callset optimization via object store convenience functions:
     # check if the not-done ones have the same callset_id
     present_callsets = {f.callset_id for f in not_done_futures}
-    if len(present_callsets) > 1:
-        raise NotImplementedError()
 
     # get the list of all objects in this callset
-    callset_id = present_callsets.pop() # FIXME assume only one
+    still_not_done_futures = []
+    while present_callsets:
+        callset_id = present_callsets.pop()
 
-    # note this returns everything done, so we have to figure out
-    # the intersection of those that are done
-    callids_done_in_callset = set(storage_handler.get_callset_status(callset_id))
+        # note this returns everything done, so we have to figure out
+        # the intersection of those that are done
+        callids_done_in_callset = set(storage_handler.get_callset_status(callset_id))
 
-    not_done_call_ids = {f.call_id for f in not_done_futures}
+        not_done_call_ids = {f.call_id for f in not_done_futures}
 
-    done_call_ids = not_done_call_ids.intersection(callids_done_in_callset)
-    not_done_call_ids = not_done_call_ids - done_call_ids
+        done_call_ids = not_done_call_ids.intersection(callids_done_in_callset)
+        not_done_call_ids = not_done_call_ids - done_call_ids
 
-    still_not_done_futures = [f for f in not_done_futures if (f.call_id in not_done_call_ids)]
+        still_not_done_futures += [f for f in not_done_futures if (f.call_id in not_done_call_ids)]
 
     def fetch_future_status(f):
         return storage_handler.get_call_status(f.callset_id, f.call_id)


### PR DESCRIPTION
Fix #179 
Tested this fix very minimally, but it seems to work for both waiting on futures that are returned by different calls to map as well as different executors. Would like feedback on whether this is sufficient or if it could possibly create issues.