### PR TITLE
fix wait on multiple callset_ids

### DIFF
--- a/pywren/wait.py
+++ b/pywren/wait.py
@@ -130,22 +130,22 @@ def _wait(fs, return_early_n, max_direct_query_n,
     ### Callset optimization via object store convenience functions:
     # check if the not-done ones have the same callset_id
     present_callsets = {f.callset_id for f in not_done_futures}
-    if len(present_callsets) > 1:
-        raise NotImplementedError()
 
     # get the list of all objects in this callset
-    callset_id = present_callsets.pop() # FIXME assume only one
+    still_not_done_futures = []
+    while present_callsets:
+        callset_id = present_callsets.pop()
 
-    # note this returns everything done, so we have to figure out
-    # the intersection of those that are done
-    callids_done_in_callset = set(storage_handler.get_callset_status(callset_id))
+        # note this returns everything done, so we have to figure out
+        # the intersection of those that are done
+        callids_done_in_callset = set(storage_handler.get_callset_status(callset_id))
 
-    not_done_call_ids = {f.call_id for f in not_done_futures}
+        not_done_call_ids = {f.call_id for f in not_done_futures}
 
-    done_call_ids = not_done_call_ids.intersection(callids_done_in_callset)
-    not_done_call_ids = not_done_call_ids - done_call_ids
+        done_call_ids = not_done_call_ids.intersection(callids_done_in_callset)
+        not_done_call_ids = not_done_call_ids - done_call_ids
 
-    still_not_done_futures = [f for f in not_done_futures if (f.call_id in not_done_call_ids)]
+        still_not_done_futures += [f for f in not_done_futures if (f.call_id in not_done_call_ids)]
 
     def fetch_future_status(f):
         return storage_handler.get_call_status(f.callset_id, f.call_id)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -309,6 +309,40 @@ class WaitTest(unittest.TestCase):
         res = np.array([f.result() for f in futures])
         np.testing.assert_array_equal(res, x+1)
 
+    def test_multiple_callset_id(self):
+        def wait_x_sec_and_plus_one(x):
+            time.sleep(x)
+            return x + 1
+
+        N = 10
+        x = np.arange(N)
+
+        pywx = pywren.default_executor()
+
+        futures1 = pywx.map(wait_x_sec_and_plus_one, x)
+        futures2 = pywx.map(wait_x_sec_and_plus_one, x)
+
+        fs_dones, fs_notdones = pywren.wait(futures1 + futures2,
+                                        return_when=pywren.wren.ALL_COMPLETED)
+        res = np.array([f.result() for f in fs_dones])
+        np.testing.assert_array_equal(res, np.concatenate((x,x))+1)
+
+    def test_multiple_callset_id_diff_executors(self):
+        def wait_x_sec_and_plus_one(x):
+            time.sleep(x)
+            return x + 1
+
+        N = 10
+        x = np.arange(N)
+
+        futures1 = pywren.default_executor().map(wait_x_sec_and_plus_one, x)
+        futures2 = pywren.default_executor().map(wait_x_sec_and_plus_one, x)
+
+        fs_dones, fs_notdones = pywren.wait(futures1 + futures2,
+                return_when=pywren.wren.ALL_COMPLETED)
+        res = np.array([f.result() for f in fs_dones])
+        np.testing.assert_array_equal(res, np.concatenate((x,x))+1)
+
 
 # Comment this test out as it doesn't work with the multiple executors (Vaishaal)
 # If we need this later we need to do some more monkey patching but is unclear we actually need this


### PR DESCRIPTION
Fix #179
Tested this fix very minimally, but it seems to work for both waiting on futures that are returned by different calls to map as well as different executors. Would like feedback on whether this is sufficient or if it could possibly create issues.