### PR TITLE
fix for windows path separator issues

### DIFF
--- a/pywren/serialize/util.py
+++ b/pywren/serialize/util.py
@@ -60,7 +60,7 @@ def create_mod_data(mod_paths):
             f = os.path.abspath(f)
             mod_str = open(f, 'rb').read()
 
-            dest_filename = f[len(pkg_root)+1:]
+            dest_filename = f[len(pkg_root)+1:].replace(os.sep, "/")
             module_data[dest_filename] = bytes_to_b64str(mod_str)
 
     return module_data

--- a/pywren/storage/storage.py
+++ b/pywren/storage/storage.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import
 
 import json
-import os
+import posixpath
 
 from  .exceptions import StorageNoSuchKeyError, StorageOutputNotFoundError
 from .s3_backend import S3Backend
@@ -75,7 +75,7 @@ class Storage(object):
         """
         # TODO: a better API for this is to return status for all calls in the callset. We'll fix
         #  this in scheduler refactoring.
-        callset_prefix = os.path.join(self.prefix, callset_id)
+        callset_prefix = posixpath.join(self.prefix, callset_id)
         keys = self.backend_handler.list_keys_with_prefix(callset_prefix)
         suffix = status_key_suffix
         status_keys = [k for k in keys if suffix in k]

--- a/pywren/storage/storage_utils.py
+++ b/pywren/storage/storage_utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-import os
+import posixpath
 
 from .exceptions import StorageConfigMismatchError
 
@@ -31,7 +31,7 @@ def create_func_key(prefix, callset_id):
     :param callset_id: callset's ID
     :return: function key
     """
-    func_key = os.path.join(prefix, callset_id, func_key_suffix)
+    func_key = posixpath.join(prefix, callset_id, func_key_suffix)
     return func_key
 
 
@@ -42,7 +42,7 @@ def create_agg_data_key(prefix, callset_id):
     :param callset_id: callset's ID
     :return: a key for aggregate data
     """
-    agg_data_key = os.path.join(prefix, callset_id, agg_data_key_suffix)
+    agg_data_key = posixpath.join(prefix, callset_id, agg_data_key_suffix)
     return agg_data_key
 
 
@@ -54,7 +54,7 @@ def create_data_key(prefix, callset_id, call_id):
     :param call_id: call's ID
     :return: data key
     """
-    return os.path.join(prefix, callset_id, call_id, data_key_suffix)
+    return posixpath.join(prefix, callset_id, call_id, data_key_suffix)
 
 
 def create_output_key(prefix, callset_id, call_id):
@@ -65,7 +65,7 @@ def create_output_key(prefix, callset_id, call_id):
     :param call_id: call's ID
     :return: output key
     """
-    return os.path.join(prefix, callset_id, call_id, output_key_suffix)
+    return posixpath.join(prefix, callset_id, call_id, output_key_suffix)
 
 
 def create_status_key(prefix, callset_id, call_id):
@@ -76,7 +76,7 @@ def create_status_key(prefix, callset_id, call_id):
     :param call_id: call's ID
     :return: status key
     """
-    return os.path.join(prefix, callset_id, call_id, status_key_suffix)
+    return posixpath.join(prefix, callset_id, call_id, status_key_suffix)
 
 
 def create_keys(prefix, callset_id, call_id):


### PR DESCRIPTION
Fix #261, fix #242
Backslashes in two different places are causing issues. On windows, `os.path.join` joins paths with a backslash as a separator instead of a forward slash
- in S3, this causes the keys to all be stored with backslash separators, which ignores the intended hierarchy and places everything at the root.
- "No module named pywren" is caused by the fact that the Lambda instances expect forward slashes in the module names. When it unpickles the function pickle, it doesn't see what it expects...

Here are the places I changed `os.path.join` to `posixpath.join` or otherwise enforced forward slashes:
- `storage/storage_utils.py`
- `storage/storage.py`
- `serialize/util.py`

There might be additional places that need this fix, but for now I think this is enough to fix most of the issues.

After #276, #278, and this pull request are merged in, Windows users should be able to use pywren without issues.