### PR TITLE
clean up local invoker

### DIFF
--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -24,13 +24,17 @@ import shutil
 import tempfile
 import atexit
 import glob2
+import multiprocessing
+import atexit
 import botocore
 import botocore.session
-from six.moves import queue
 from pywren import local
 
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+LOCAL_DIR = tempfile.gettempdir()
+LOCAL_RUN_DIR = os.path.join(LOCAL_DIR, "task")
 
 
 class LambdaInvoker(object):
@@ -61,21 +65,6 @@ class LambdaInvoker(object):
         return {'lambda_function_name' : self.lambda_function_name,
                 'region_name' : self.region_name}
 
-TEMP_DIR = tempfile.gettempdir()
-LOCAL_RUN_DIR = os.path.join(TEMP_DIR, "task")
-def local_clean():
-    dirs = glob2.glob(os.path.join(TEMP_DIR, 'pymodules*'))
-    dirs.append(LOCAL_RUN_DIR)
-    dirs.append(os.path.join(TEMP_DIR, 'runtimes'))
-    files = [os.path.join(TEMP_DIR, 'runtime_download_lock')]
-    files += glob2.glob(os.path.join(TEMP_DIR, 'jobrunner*'))
-    files += glob2.glob(os.path.join(TEMP_DIR, 'condaruntime_*'))
-    for d in dirs:
-        shutil.rmtree(d, True)
-    for f in files:
-        if os.path.exists(f):
-            os.remove(f)
-
 
 class DummyInvoker(object):
     """
@@ -87,7 +76,7 @@ class DummyInvoker(object):
         self.payloads = []
         self.TIME_LIMIT = False
         self.thread = None
-        atexit.register(local_clean)
+        atexit.register(local.clean, LOCAL_DIR)
 
     def invoke(self, payload):
         self.payloads.append(payload)
@@ -138,24 +127,22 @@ class LocalInvoker(object):
 
     def __init__(self, run_dir=LOCAL_RUN_DIR):
 
-        self.running = True
-
-        self.queue = queue.Queue()
-        self.thread = threading.Thread(target=self._thread_runner)
-        self.thread.daemon = True
+        self.queue = multiprocessing.Queue()
+        shutil.rmtree(run_dir, True)
         self.run_dir = run_dir
-        self.thread.start()
-        atexit.register(local_clean)
+        for _ in range(multiprocessing.cpu_count()):
+            p = multiprocessing.Process(target=self._process_runner)
+            p.daemon = True
+            p.start()
+
+        atexit.register(local.clean, LOCAL_DIR)
 
 
-    def _thread_runner(self):
+    def _process_runner(self):
         while True:
-            res = self.queue.get(True)
-            jobs = [res]
-
-            local.local_handler(jobs, self.run_dir,
+            res = self.queue.get(block=True)
+            local.local_handler(res, self.run_dir,
                                 {'invoker' : 'LocalInvoker'})
-            self.queue.task_done()
 
     def invoke(self, payload):
         self.queue.put(payload)

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -22,10 +22,7 @@ import threading
 import sys
 import shutil
 import tempfile
-import atexit
-import glob2
 import multiprocessing
-import atexit
 import botocore
 import botocore.session
 from pywren import local
@@ -76,7 +73,6 @@ class DummyInvoker(object):
         self.payloads = []
         self.TIME_LIMIT = False
         self.thread = None
-        atexit.register(local.clean, LOCAL_DIR)
 
     def invoke(self, payload):
         self.payloads.append(payload)
@@ -134,8 +130,6 @@ class LocalInvoker(object):
             p = multiprocessing.Process(target=self._process_runner)
             p.daemon = True
             p.start()
-
-        atexit.register(local.clean, LOCAL_DIR)
 
 
     def _process_runner(self):

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -118,7 +118,15 @@ class DummyInvoker(object):
 
 class LocalInvoker(object):
     """
-    An invoker which spawns a thread that then waits for jobs on a queue
+    An invoker which spawns a thread that then waits 
+    for jobs on a queue. This is a more self-contained invoker in that
+    it doesn't require the run_jobs() of the dummy invoker, but also
+    needs to be explictly shut down due to python threading semantics. 
+
+    
+
+    Note this invoker must be created independently and passed in
+    
     """
 
     def __init__(self, run_dir="/tmp/task"):
@@ -131,9 +139,14 @@ class LocalInvoker(object):
 
         self.queue = queue.Queue()
         self.thread = threading.Thread(target=self._thread_runner)
-        self.thread.start()
         self.run_dir = run_dir
 
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.quit()
 
     def quit(self):
         self.running = False

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -127,14 +127,21 @@ class LocalInvoker(object):
         if not sys.platform.startswith('linux'):
             raise RuntimeError("LocalInvoker can only be run under linux")
 
+        self.running = True
+
         self.queue = queue.Queue()
         self.thread = threading.Thread(target=self._thread_runner)
         self.thread.start()
         self.run_dir = run_dir
 
+
+    def quit(self):
+        self.running = False
+        self.thread.join()
+
     def _thread_runner(self):
         BLOCK_SEC_MAX = 10
-        while True:
+        while self.running:
             try:
                 res = self.queue.get(True, BLOCK_SEC_MAX)
                 jobs = [res]

--- a/pywren/invokers.py
+++ b/pywren/invokers.py
@@ -98,7 +98,7 @@ class DummyInvoker(object):
             jobn = MAXJOBS
         jobs = self.payloads[:jobn]
 
-        local.local_handler(jobs, run_dir,
+        local.dummy_handler(jobs, run_dir,
                             {'invoker' : 'DummyInvoker'})
 
         self.payloads = self.payloads[jobn:]

--- a/pywren/local.py
+++ b/pywren/local.py
@@ -64,16 +64,3 @@ def local_handler(job, run_dir, extra_context=None):
     Runs a job locally inside of run_dir, used by local invoker
     """
     run_generic_handler(job, str(os.getpid()), os.getcwd(), run_dir, extra_context)
-
-def clean(local_dir):
-    dirs = glob.glob(os.path.join(local_dir, 'pymodules*'))
-    dirs.append(os.path.join(local_dir, 'task'))
-    dirs.append(os.path.join(local_dir, 'runtimes'))
-    for d in dirs:
-        shutil.rmtree(d, ignore_errors=True)
-    files = [os.path.join(local_dir, 'runtime_download_lock')]
-    files += glob.glob(os.path.join(local_dir, 'jobrunner*'))
-    files += glob.glob(os.path.join(local_dir, 'condaruntime*'))
-    for f in files:
-        if os.path.exists(f) or os.path.islink(f):
-            os.unlink(f)

--- a/pywren/local.py
+++ b/pywren/local.py
@@ -31,7 +31,6 @@ def local_handler(jobs, run_dir, extra_context=None):
 
     Just for debugging
     """
-    # FIXME throw an error if invoked on non-linux machines
 
     def copy_runtime(tgt_dir):
         files = glob.glob(os.path.join(pywren.SOURCE_DIR, "./*.py"))
@@ -43,7 +42,6 @@ def local_handler(jobs, run_dir, extra_context=None):
 
     for job_i, job in enumerate(jobs):
         local_task_run_dir = os.path.join(run_dir, str(job_i))
-
         shutil.rmtree(local_task_run_dir, True) # delete old modules
         os.makedirs(local_task_run_dir)
         copy_runtime(local_task_run_dir)

--- a/pywren/local.py
+++ b/pywren/local.py
@@ -23,13 +23,8 @@ import shutil
 import pywren
 from . import wrenhandler
 
-def local_handler(payload, run_dir, extra_context=None):
-    """
-    Run a list of (deserialized) jobs locally inside of
-    run_dir
 
-    Just for debugging
-    """
+def run_generic_handler(job, job_id, original_dir, run_dir, extra_context):
 
     def copy_runtime(tgt_dir):
         files = glob.glob(os.path.join(pywren.SOURCE_DIR, "./*.py"))
@@ -37,23 +32,38 @@ def local_handler(payload, run_dir, extra_context=None):
         for f in files:
             shutil.copy(f, os.path.join(tgt_dir, os.path.basename(f)))
 
-    original_dir = os.getcwd()
-
-    local_task_run_dir = os.path.join(run_dir, str(os.getpid()))
+    local_task_run_dir = os.path.join(run_dir, job_id)
     if not os.path.exists(local_task_run_dir):
         os.makedirs(local_task_run_dir)
         copy_runtime(local_task_run_dir)
 
 
-    context = {'jobnum' : os.getpid()}
+    context = {'jobnum' : job_id}
     if extra_context is not None:
         context.update(extra_context)
 
     os.chdir(local_task_run_dir)
     # FIXME debug
-    wrenhandler.generic_handler(payload, context)
+    wrenhandler.generic_handler(job, context)
 
     os.chdir(original_dir)
+
+def dummy_handler(jobs, run_dir, extra_context=None):
+    """
+    Run a list of (deserialized) jobs locally inside of
+    run_dir, used by dummy invoker
+
+    Just for debugging
+    """
+    original_dir = os.getcwd()
+    for job_i, job in enumerate(jobs):
+        run_generic_handler(job, str(job_i), original_dir, run_dir, extra_context)
+
+def local_handler(job, run_dir, extra_context=None):
+    """
+    Runs a job locally inside of run_dir, used by local invoker
+    """
+    run_generic_handler(job, str(os.getpid()), os.getcwd(), run_dir, extra_context)
 
 def clean(local_dir):
     dirs = glob.glob(os.path.join(local_dir, 'pymodules*'))

--- a/pywren/local.py
+++ b/pywren/local.py
@@ -31,6 +31,7 @@ def local_handler(jobs, run_dir, extra_context=None):
 
     Just for debugging
     """
+    # FIXME throw an error if invoked on non-linux machines
 
     def copy_runtime(tgt_dir):
         files = glob.glob(os.path.join(pywren.SOURCE_DIR, "./*.py"))
@@ -42,6 +43,7 @@ def local_handler(jobs, run_dir, extra_context=None):
 
     for job_i, job in enumerate(jobs):
         local_task_run_dir = os.path.join(run_dir, str(job_i))
+
         shutil.rmtree(local_task_run_dir, True) # delete old modules
         os.makedirs(local_task_run_dir)
         copy_runtime(local_task_run_dir)

--- a/pywren/queues.py
+++ b/pywren/queues.py
@@ -78,7 +78,7 @@ def sqs_run_local(region_name, sqs_queue_name, job_num=1,
                 job = json.loads(m.body)
 
                 m.delete()
-                local.local_handler([job], run_dir,
+                local.dummy_handler([job], run_dir,
                                     {'invoker' : 'SQSInvoker',
                                      'job_i' : job_i})
                 print("done with invocation")

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -50,6 +50,8 @@ def default_executor(**kwargs):
         return remote_executor(**kwargs)
     elif executor_str == 'dummy':
         return dummy_executor(**kwargs)
+    elif executor_str == 'local':
+        return local_executor(**kwargs)
     return lambda_executor(**kwargs)
 
 
@@ -82,13 +84,15 @@ def remote_executor(config=None, job_max_runtime=3600):
 
     return Executor(invoker, config, job_max_runtime)
 
-def local_executor(invoker_object=None, 
+def local_executor(invoker_object=None,
                    config=None, job_max_runtime=300):
     if config is None:
         config = wrenconfig.default()
     if invoker_object is None:
-        run_dir = config.get("local_run_dir", "/tmp/task")
-        invoker = invokers.LocalInvoker(run_dir=run_dir)
+        if "local_run_dir" in config:
+            invoker = invokers.LocalInvoker(run_dir=config["local_run_dir"])
+        else:
+            invoker = invokers.LocalInvoker()
     else:
         invoker = invoker_object
     return Executor(invoker, config, job_max_runtime)

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -82,11 +82,15 @@ def remote_executor(config=None, job_max_runtime=3600):
 
     return Executor(invoker, config, job_max_runtime)
 
-def local_executor(config=None, job_max_runtime=300):
+def local_executor(invoker_object=None, 
+                   config=None, job_max_runtime=300):
     if config is None:
         config = wrenconfig.default()
-    run_dir = config.get("local_run_dir", "/tmp/task")
-    invoker = invokers.LocalInvoker(run_dir=run_dir)
+    if invoker_object is None:
+        run_dir = config.get("local_run_dir", "/tmp/task")
+        invoker = invokers.LocalInvoker(run_dir=run_dir)
+    else:
+        invoker = invoker_object
     return Executor(invoker, config, job_max_runtime)
 
 standalone_executor = remote_executor

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -82,6 +82,13 @@ def remote_executor(config=None, job_max_runtime=3600):
 
     return Executor(invoker, config, job_max_runtime)
 
+def local_executor(config=None, job_max_runtime=300):
+    if config is None:
+        config = wrenconfig.default()
+    run_dir = config.get("local_run_dir", "/tmp/task")
+    invoker = invokers.LocalInvoker(run_dir=run_dir)
+    return Executor(invoker, config, job_max_runtime)
+
 standalone_executor = remote_executor
 
 

--- a/tests/test_local_invoker.py
+++ b/tests/test_local_invoker.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2018 PyWren Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import time
+import boto3 
+import uuid
+import numpy as np
+import time
+import pywren
+import subprocess
+import logging
+import unittest
+import numpy as np
+from flaky import flaky
+
+class SimpleAsync(unittest.TestCase):
+
+    def setUp(self):
+        self.wrenexec = pywren.local_executor()
+
+    def test_simple(self):
+
+        def sum_list(x):
+            return np.sum(x)
+
+        x = np.arange(10)
+        fut = self.wrenexec.call_async(sum_list, x)
+        
+        res = fut.result() 
+        self.assertEqual(res, np.sum(x))
+
+    def test_simple_map(self):
+
+        def plus_one(x):
+            return x + 1
+
+        x = np.arange(4)
+        futures = self.wrenexec.map(plus_one, x)
+        
+        res = pywren.get_all_results(futures)
+        np.testing.assert_array_equal(res, x + 1)
+
+    def test_exception(self):
+        def throwexcept(x):
+            raise Exception("Throw me out!")
+
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(throwexcept, None)
+        
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+        assert 'Throw me out!' in str(execinfo.value)
+
+
+    def test_subprocess(self):
+        def uname(x):
+            return subprocess.check_output("uname -a", shell=True)
+        
+        fut = self.wrenexec.call_async(uname, None)
+
+        res = fut.result() 
+
+


### PR DESCRIPTION
Made local invoker portable and semantically equivalent to a lambda invoker. This just involved making the local invoker's thread daemonic so that the program would exit when the main thread exits. ~However, it's possible there is a reason this was not done from the beginning, would like input on whether this is fine.~

Also added some tests, in test_local_invoker.py, which was just lifted from the dummy invoker tests.