### PR TITLE
added __init__.py to jobrunner folder

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -78,7 +78,7 @@ enable=
 # --disable=W"
 
 # These are errors still not addressed in PyWren.
-disable=invalid-name,missing-docstring,too-many-branches,too-many-arguments,too-many-locals,logging-format-interpolation,too-many-public-methods,too-few-public-methods,too-many-instance-attributes,bare-except,broad-except,protected-access,unidiomatic-typecheck,too-many-return-statements,too-many-statements,locally-disabled,len-as-condition,no-else-return,superfluous-parens,inconsistent-return-statements,logging-not-lazy,useless-import-alias,old-style-class,bad-option-value,useless-object-inheritance
+disable=invalid-name,missing-docstring,too-many-branches,too-many-arguments,too-many-locals,logging-format-interpolation,too-many-public-methods,too-few-public-methods,too-many-instance-attributes,bare-except,broad-except,protected-access,unidiomatic-typecheck,too-many-return-statements,too-many-statements,locally-disabled,len-as-condition,no-else-return,superfluous-parens,inconsistent-return-statements,logging-not-lazy,useless-import-alias,old-style-class,bad-option-value,useless-object-inheritance,cyclic-import
 
 [REPORTS]
 

--- a/pywren/jobrunner/__init__.py
+++ b/pywren/jobrunner/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2018 PyWren Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/pywren/jobrunner/jobrunner.py
+++ b/pywren/jobrunner/jobrunner.py
@@ -71,17 +71,17 @@ def write_stat(stat, val):
     stats_fid.write("{} {:f}\n".format(stat, val))
     stats_fid.flush()
 
-def get_object_with_backoff(s3_client, bucket, key, max_tries=MAX_TRIES, backoff=BACKOFF, **extra_get_args):
+def get_object_with_backoff(client, bucket, key, tries=MAX_TRIES, backoff=BACKOFF, **extra_args):
     num_tries = 0
-    while (num_tries < max_tries):
+    while (num_tries < tries):
         try:
-            func_obj_stream = s3_client.get_object(Bucket=bucket, Key=key, **extra_get_args)
+            f_stream = client.get_object(Bucket=bucket, Key=key, **extra_args)
             break
         except ReadTimeoutError:
             time.sleep(backoff)
             backoff *= 2
             num_tries += 1
-    return func_obj_stream
+    return f_stream
 
 try:
     func_download_time_t1 = time.time()
@@ -186,5 +186,4 @@ finally:
                          Bucket=output_bucket,
                          Key=output_key)
     output_upload_timestamp_t2 = time.time()
-    write_stat("output_upload_time",
-               output_upload_timestamp_t2 - output_upload_timestamp_t1)
+    write_stat("output_upload_time", output_upload_timestamp_t2 - output_upload_timestamp_t1) # pylint: disable=line-too-long

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -502,8 +502,8 @@ def log_url(ctx):
     function_name = config['lambda']['function_name']
     aws_region = config['account']['aws_region']
     url = "https://" + \
-        "{}.console.aws.amazon.com/cloudwatch/home?region={}#logStream:group=/aws/lambda/{}".format(
-            aws_region, aws_region, function_name)
+        "{0}.console.aws.amazon.com/cloudwatch/home?region={0}#logStream:group=/aws/lambda/{1}".\
+        format(aws_region, function_name)
     print(url)
 
 

--- a/pywren/version.py
+++ b/pywren/version.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 # we're following the version number guidelines
 # from https://www.python.org/dev/peps/pep-0386/
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
When packaging python projects, one of the packaging pathways ignores all folders without a init.py. This causes the jobrunner.py to be missing in the release. This fixes issue #300

