### PR TITLE
[FIX] Upgrade PyWren to use Python3.7 runtime on AWS Lambda

### DIFF
--- a/pywren/future.py
+++ b/pywren/future.py
@@ -162,7 +162,8 @@ class ResponseFuture:
 
         ## FIXME implement timeout
         if timeout is not None:
-            raise NotImplementedError()
+            logging.warning('timeout not yet implemented, has no effect yet.')
+            #raise NotImplementedError()
 
         if check_only:
             if call_status is None:

--- a/pywren/future.py
+++ b/pywren/future.py
@@ -163,7 +163,6 @@ class ResponseFuture:
         ## FIXME implement timeout
         if timeout is not None:
             logging.warning('timeout not yet implemented, has no effect yet.')
-            #raise NotImplementedError()
 
         if check_only:
             if call_status is None:

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -297,11 +297,13 @@ def deploy_lambda(ctx, update_if_exists=True):
         f = os.path.abspath(os.path.join(module_dir, f))
 
         # need to put everything into an extra folder an add an empty __init__.py file to make things work
-        a = 'app/' + os.path.basename(f) # , SOURCE_DIR + "/..")
+        a = os.path.join('app', os.path.basename(f)) # , SOURCE_DIR + "/..")
+        print('addding to {}'.format(a))
         zipfile_obj.write(f, arcname=a)
 
     # add empty file.
-    zipfile_obj.writestr("app/__init__.py", "");
+    zipfile_obj.writestr("app/__init__.py", "")
+    print('addding to {}'.format("app/__init__.py"))
 
     zipfile_obj.close()
     #open("/tmp/deploy.zip", 'w').write(file_like_object.getvalue())

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -295,8 +295,14 @@ def deploy_lambda(ctx, update_if_exists=True):
     for f in ['wrenutil.py', 'wrenconfig.py', 'wrenhandler.py',
               'version.py', 'jobrunner/jobrunner.py', 'wren.py']:
         f = os.path.abspath(os.path.join(module_dir, f))
-        a = os.path.basename(f) # , SOURCE_DIR + "/..")
+
+        # need to put everything into an extra folder an add an empty __init__.py file to make things work
+        a = 'app/' + os.path.basename(f) # , SOURCE_DIR + "/..")
         zipfile_obj.write(f, arcname=a)
+
+    # add empty file.
+    zipfile_obj.writestr("app/__init__.py", "");
+
     zipfile_obj.close()
     #open("/tmp/deploy.zip", 'w').write(file_like_object.getvalue())
 
@@ -328,7 +334,7 @@ def deploy_lambda(ctx, update_if_exists=True):
 
                 lambclient.create_function(FunctionName=FUNCTION_NAME,
                                            Handler=pywren.wrenconfig.AWS_LAMBDA_HANDLER_NAME,
-                                           Runtime="python3.9",
+                                           Runtime="python3.7",
                                            MemorySize=MEMORY,
                                            Timeout=TIMEOUT,
                                            Role=ROLE,
@@ -456,7 +462,7 @@ def test_function(ctx):
         return "Hello world"
 
     fut = wrenexec.call_async(hello_world, None)
-    res = fut.result(storage_handler=wrenexec.storage)
+    res = fut.result(storage_handler=wrenexec.storage, timeout=10)
 
     click.echo("function returned: {}".format(res))
 

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -297,16 +297,16 @@ def deploy_lambda(ctx, update_if_exists=True):
         f = os.path.abspath(os.path.join(module_dir, f))
 
         # need to put everything into an extra folder an add an empty __init__.py file to make things work
-        a = os.path.join('app', os.path.basename(f)) # , SOURCE_DIR + "/..")
-        print('addding to {}'.format(a))
+        # for this add folder app/ and store all runner files within it.
+        a = os.path.join('app', os.path.basename(f))
+        logging.debug('addding to {}'.format(a))
         zipfile_obj.write(f, arcname=a)
 
-    # add empty file.
+    # add __init__.py to make app/ a python module
     zipfile_obj.writestr("app/__init__.py", "")
-    print('addding to {}'.format("app/__init__.py"))
+    logging.debug('addding to {}'.format("app/__init__.py"))
 
     zipfile_obj.close()
-    #open("/tmp/deploy.zip", 'w').write(file_like_object.getvalue())
 
     lambclient = boto3.client('lambda', region_name=AWS_REGION)
 
@@ -345,8 +345,6 @@ def deploy_lambda(ctx, update_if_exists=True):
                 break
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == "InvalidParameterValueException":
-
-                print(e)
 
                 retries += 1
 

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -28,6 +28,7 @@ import boto3
 import botocore
 import botocore.exceptions
 import click
+import logging
 import pywren
 import pywren.runtime
 from pywren import ec2standalone

--- a/pywren/scripts/pywrencli.py
+++ b/pywren/scripts/pywrencli.py
@@ -328,7 +328,7 @@ def deploy_lambda(ctx, update_if_exists=True):
 
                 lambclient.create_function(FunctionName=FUNCTION_NAME,
                                            Handler=pywren.wrenconfig.AWS_LAMBDA_HANDLER_NAME,
-                                           Runtime="python2.7",
+                                           Runtime="python3.9",
                                            MemorySize=MEMORY,
                                            Timeout=TIMEOUT,
                                            Role=ROLE,
@@ -337,6 +337,8 @@ def deploy_lambda(ctx, update_if_exists=True):
                 break
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == "InvalidParameterValueException":
+
+                print(e)
 
                 retries += 1
 

--- a/pywren/scripts/setupscript.py
+++ b/pywren/scripts/setupscript.py
@@ -23,6 +23,7 @@ import time
 import boto3
 import botocore
 import click
+import logging
 import pywren.wrenconfig
 from pywren.scripts import pywrencli
 

--- a/pywren/scripts/setupscript.py
+++ b/pywren/scripts/setupscript.py
@@ -219,7 +219,7 @@ def interactive_setup(ctx, dryrun, suffix):
         ctx.invoke(pywrencli.create_instance_profile)
     click.echo("Pausing for 10 sec for changes to propagate.")
     time.sleep(10)
-    click.echo("Invoking test_function to see whether it works now...")
+    click.echo("Invoking test_function.")
     ctx.invoke(pywrencli.test_function)
     click.echo("All ok.")
 

--- a/pywren/scripts/setupscript.py
+++ b/pywren/scripts/setupscript.py
@@ -219,7 +219,9 @@ def interactive_setup(ctx, dryrun, suffix):
         ctx.invoke(pywrencli.create_instance_profile)
     click.echo("Pausing for 10 sec for changes to propagate.")
     time.sleep(10)
+    click.echo("Invoking test_function to see whether it works now...")
     ctx.invoke(pywrencli.test_function)
+    click.echo("All ok.")
 
 if __name__ == '__main__':
     interactive_setup() # pylint: disable=no-value-for-parameter

--- a/pywren/wrenconfig.py
+++ b/pywren/wrenconfig.py
@@ -19,7 +19,8 @@ import copy
 
 
 GENERIC_HANDLER_NAME = "wrenhandler.generic_handler"
-AWS_LAMBDA_HANDLER_NAME = "wrenhandler.aws_lambda_handler"
+# to fix the issue https://gist.github.com/gene1wood/06a64ba80cf3fe886053f0ca6d375bc0 stemming from upgrading to Python3.x use new directory structure
+AWS_LAMBDA_HANDLER_NAME = "app.wrenhandler.aws_lambda_handler"
 
 PACKAGE_FILE = "deploy.zip"
 

--- a/pywren/wrenconfig.py
+++ b/pywren/wrenconfig.py
@@ -19,7 +19,8 @@ import copy
 
 
 GENERIC_HANDLER_NAME = "wrenhandler.generic_handler"
-# to fix the issue https://gist.github.com/gene1wood/06a64ba80cf3fe886053f0ca6d375bc0 stemming from upgrading to Python3.x use new directory structure
+# to fix the issue https://gist.github.com/gene1wood/06a64ba80cf3fe886053f0ca6d375bc0 causewd by upgrading
+# runtime to Python3.x use new directory structure, i.e. place all runner files in app/ folder.
 AWS_LAMBDA_HANDLER_NAME = "app.wrenhandler.aws_lambda_handler"
 
 PACKAGE_FILE = "deploy.zip"

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -302,7 +302,7 @@ def generic_handler(event, context_dict, custom_handler_env=None):
         response_status['runtime_cached'] = runtime_cached
 
         cwd = os.getcwd()
-        jobrunner_path = os.path.join(cwd, "jobrunner.py")
+        jobrunner_path = os.path.join(cwd, "app/jobrunner.py")
 
         extra_env = event.get('extra_env', {})
         extra_env['PYTHONPATH'] = "{}".format(os.getcwd())

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,5 @@ setup(
                    'ec2_standalone_files/cloudwatch-agent.config',
                    'jobrunner/jobrunner.py'
         ]},
-    dependency_links=['https://github.com/kislyuk/watchtower/tarball/master#egg=watchtower-0.3.4'],
     include_package_data=True
 )


### PR DESCRIPTION
Python 2.7 runtime support has ended in AWS (cf. https://aws.amazon.com/blogs/compute/announcing-end-of-support-for-python-2-7-in-aws-lambda/). This small PR introduces necessary changes to use Python3.7 runtime instead. 

Details:
- New directory structure required by Python3.7 runtime
- Updated dependencies in setup.py
- Adjusted runner files to new directory structure